### PR TITLE
Add nighttime zeros to PVLive data - fixes #104

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "tqdm",
     "loguru==0.7.3",
     "pvlive-api>=1.5.1",
+    "pvliveconsumer",
 ]
 
 [dependency-groups]

--- a/solar_consumer/data/fetch_gb_data.py
+++ b/solar_consumer/data/fetch_gb_data.py
@@ -8,6 +8,7 @@ from loguru import logger
 from datetime import datetime, timedelta, timezone
 
 from pvlive_api import PVLive
+from pvliveconsumer.nightime import make_night_time_zeros
 
 
 def fetch_gb_data(historic_or_forecast: str = "forecast") -> pd.DataFrame:
@@ -134,6 +135,7 @@ def fetch_gb_data_historic(regime: str) -> pd.DataFrame:
         # TODO if did not find any values,
         # https://github.com/openclimatefix/solar-consumer/issues/104
         # Make nighttime zeros
+        gsp_yield_df = make_night_time_zeros(start, end, gsp_id, gsp_yield_df, regime)
 
         # capacity is zero, set generation to 0
         if gsp_yield_df["capacity_mwp"].sum() == 0:


### PR DESCRIPTION
# Pull Request


**Changes made:**
- Added import for `make_night_time_zeros` from `pvliveconsumer.nightime`
- Added function call in the PVLive data processing loop to fill nighttime gaps
- Added `pvliveconsumer` dependency to `pyproject.toml`


Fixes 104


Update: Failed tests, fixing them
