### PR TITLE
Add fetch_be_forecast function to get Belgium solar forecast (regiona…

### DIFF
--- a/solar_consumer/fetch_data.py
+++ b/solar_consumer/fetch_data.py
@@ -9,7 +9,6 @@ import urllib.request
 import urllib.parse
 import json
 import pandas as pd
-import requests
 from solar_consumer.data.fetch_gb_data import fetch_gb_data
 from solar_consumer.data.fetch_nl_data import fetch_nl_data
 from solar_consumer.data.fetch_de_data import fetch_de_data
@@ -26,7 +25,7 @@ def fetch_data(country: str = "gb", historic_or_forecast: str = "forecast") -> p
         solar_generation_kw: Solar generation in kW. Can be a forecast, or historic values
     """
 
-    country_data_functions = {"gb": fetch_gb_data, "nl": fetch_nl_data, "de": fetch_de_data, "be": fetch_be_data,}
+    country_data_functions = {"gb": fetch_gb_data, "nl": fetch_nl_data, "de": fetch_de_data, "be": fetch_be_forecast,}
 
     if country in country_data_functions:
         try:


### PR DESCRIPTION
…l + national)

# Pull Request

## Description

This PR introduces a new function `fetch_be_forecast` to retrieve Belgium solar forecast data from Elia open data. The function collects both regional and national forecasts, standardizes column names, and ensures the datetime column is properly converted to UTC.

Related issue: Fixes #127

## How Has This Been Tested?

- Function tested locally by fetching the CSV from Elia.
- Verified columns: `target_datetime_utc`, `Region`, `solar_generation_kw`.
- Converted the `Datetime` column to datetime format in UTC successfully.
- Verified that both regional and national forecasts are included in the resulting DataFrame.

## Checklist

- [x] My code follows [Open Climate Fix coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] Self-review performed for correctness and readability
- [x] Function tested locally and verified for correctness
- [ ] Documentation updated (not required for this PR)
- [ ] Additional tests added (not required for this PR)
- [x] Spelling and grammar checked
