### PR TITLE
Fix Docker build and enable git-based versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN rm -rf /app/.venv/lib/python3.12/site-packages/**/tests
 FROM build-deps AS build-app
 
 # Install full project
+COPY .git /app/.git
 COPY . /app
 RUN uv sync --no-dev --no-editable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = [
+    "setuptools>=61.0",
+    "setuptools-git-versioning"
+]
 build-backend = "setuptools.build_meta"
+
 
 [project]
 name = "solar_consumer"

--- a/solar_consumer/__init__.py
+++ b/solar_consumer/__init__.py
@@ -4,4 +4,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("solar_consumer")
 except PackageNotFoundError:
-    __version__ = "v?"
+    __version__ = "0.0.0"


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes an issue where Docker builds always reported the application
version as `0.0.0`, even when git tags were present.

### What changed
- Added `setuptools-git-versioning` to `build-system.requires` so the plugin
  is available at build time.
- Ensured git metadata is available during the Docker build stage.
- Confirmed the runtime reads the version from package metadata instead of
  relying on git at runtime.

### Why
Without `setuptools-git-versioning` installed at build time, setuptools
silently fell back to `0.0.0`. This caused incorrect version logging in
production Docker images.

With this change, Docker images correctly reflect the git tag version
(e.g. `1.4.14`) in logs.

Fixes #126 

## How Has This Been Tested?

- Built the Docker image locally using `docker build --no-cache`.
- Ran the container and verified the startup logs report the correct version.
- Verified runtime version directly using:
  `python -c "from solar_consumer import __version__; print(__version__)"`


- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
