### PR TITLE
modified save_site_database.py for nl and added new tests

### DIFF
--- a/tests/integration/test_nl_capacity_integration.py
+++ b/tests/integration/test_nl_capacity_integration.py
@@ -1,0 +1,71 @@
+import pytest
+from datetime import datetime, timezone
+import pandas as pd
+from solar_consumer.save.save_site_database import save_generation_to_site_db
+from pvsite_datamodel.sqlmodels import GenerationSQL
+
+
+@pytest.mark.integration
+def test_save_aborts_with_funky_capacity(db_site_session):
+    """
+    Test that save_generation_to_site_db aborts when validation fails
+    """
+    timestamp = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    
+    # Create funky data where regional sum (60,000) doesn't match national (30,000)
+    data = [
+        {'target_datetime_utc': timestamp, 'region_id': 0, 'capacity_kw': 30_000, 'solar_generation_kw': 15_000}
+    ]
+    for region_id in range(1, 13):
+        data.append({
+            'target_datetime_utc': timestamp,
+            'region_id': region_id,
+            'capacity_kw': 5_000,  # 12 * 5000 = 60,000 (funky!)
+            'solar_generation_kw': 2_500
+        })
+    
+    funky_df = pd.DataFrame(data)
+    
+    # Try to save - should abort
+    save_generation_to_site_db(
+        generation_data=funky_df,
+        session=db_site_session,
+        country="nl"
+    )
+    
+    # Verify nothing was saved
+    saved_data = db_site_session.query(GenerationSQL).all()
+    assert len(saved_data) == 0, "No data should be saved when validation fails"
+
+
+@pytest.mark.integration
+def test_save_succeeds_with_valid_capacity(db_site_session):
+    """
+    Test that save_generation_to_site_db saves when validation passes
+    """
+    timestamp = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    
+    # Create valid data where regional sum (30,000) matches national (30,000)
+    data = [
+        {'target_datetime_utc': timestamp, 'region_id': 0, 'capacity_kw': 30_000, 'solar_generation_kw': 15_000}
+    ]
+    for region_id in range(1, 13):
+        data.append({
+            'target_datetime_utc': timestamp,
+            'region_id': region_id,
+            'capacity_kw': 2_500,  # 12 * 2500 = 30,000 (valid!)
+            'solar_generation_kw': 1_250
+        })
+    
+    valid_df = pd.DataFrame(data)
+    
+    # Save should succeed
+    save_generation_to_site_db(
+        generation_data=valid_df,
+        session=db_site_session,
+        country="nl"
+    )
+    
+    # Verify data was saved (13 sites: 1 national + 12 regions)
+    saved_data = db_site_session.query(GenerationSQL).all()
+    assert len(saved_data) == 13, f"Expected 13 records, got {len(saved_data)}"

--- a/tests/unit/test_nl_capacity_validation.py
+++ b/tests/unit/test_nl_capacity_validation.py
@@ -1,0 +1,84 @@
+import pandas as pd
+from datetime import datetime, timezone
+from solar_consumer.save.save_site_database import validate_nl_capacities
+
+
+def test_valid_capacities_pass():
+    """Test that valid capacity data passes validation"""
+    timestamp = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    
+    data = [
+        {'target_datetime_utc': timestamp, 'region_id': 0, 'capacity_kw': 30_000, 'solar_generation_kw': 15_000}
+    ]
+    # 12 regions, each 2,500 kW = 30,000 kW total (matches national)
+    for region_id in range(1, 13):
+        data.append({
+            'target_datetime_utc': timestamp,
+            'region_id': region_id,
+            'capacity_kw': 2_500,
+            'solar_generation_kw': 1_250
+        })
+    
+    df = pd.DataFrame(data)
+    assert validate_nl_capacities(df, tolerance=0.001) is True
+
+
+def test_funky_high_capacities_fail():
+    """Test that funky high regional capacities fail validation"""
+    timestamp = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    
+    data = [
+        {'target_datetime_utc': timestamp, 'region_id': 0, 'capacity_kw': 30_000, 'solar_generation_kw': 15_000}
+    ]
+    # Regional sum: 60,000 kW (double the national!)
+    for region_id in range(1, 13):
+        data.append({
+            'target_datetime_utc': timestamp,
+            'region_id': region_id,
+            'capacity_kw': 5_000,  # Way too high
+            'solar_generation_kw': 2_500
+        })
+    
+    df = pd.DataFrame(data)
+    assert validate_nl_capacities(df, tolerance=0.001) is False
+
+
+def test_funky_low_capacities_fail():
+    """Test that funky low regional capacities fail validation"""
+    timestamp = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    
+    data = [
+        {'target_datetime_utc': timestamp, 'region_id': 0, 'capacity_kw': 30_000, 'solar_generation_kw': 15_000}
+    ]
+    # Regional sum: 12,000 kW (way too low)
+    for region_id in range(1, 13):
+        data.append({
+            'target_datetime_utc': timestamp,
+            'region_id': region_id,
+            'capacity_kw': 1_000,  # Too low
+            'solar_generation_kw': 500
+        })
+    
+    df = pd.DataFrame(data)
+    assert validate_nl_capacities(df, tolerance=0.001) is False
+
+
+def test_within_30mw_tolerance_passes():
+    """Test the specific 30MW tolerance mentioned in the issue"""
+    timestamp = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    
+    data = [
+        {'target_datetime_utc': timestamp, 'region_id': 0, 'capacity_kw': 30_000, 'solar_generation_kw': 15_000}
+    ]
+    # Regional sum: 30,029 kW (29 kW = 0.029 MW difference - within tolerance)
+    for region_id in range(1, 13):
+        capacity = 2_529 if region_id == 1 else 2_500
+        data.append({
+            'target_datetime_utc': timestamp,
+            'region_id': region_id,
+            'capacity_kw': capacity,
+            'solar_generation_kw': 1_250
+        })
+    
+    df = pd.DataFrame(data)
+    assert validate_nl_capacities(df, tolerance=0.001) is True


### PR DESCRIPTION
# Pull Request

## Description

This PR adds validation for Netherlands (NL) solar capacity data to prevent inconsistent (“funky”) regional capacity values from being saved to the site database.

A new helper function validate_nl_capacities checks, per timestamp, that the sum of regional capacities (regions 1–12) matches the national capacity (region 0) within a configurable tolerance (default 0.1%). If the validation fails, the save process is aborted to avoid persisting bad data.

The validation is integrated into save_generation_to_site_db() and only runs for NL data when the required columns (capacity_kw, region_id) are present.

Fixes #135 

## How Has This Been Tested?

Unit tests were added to cover:
- Valid capacity data passing validation
- Regional capacities that are too high or too low failing validation
- Edge cases within the documented tolerance (~30 MW for NL)

Integration tests were added to ensure:
- save_generation_to_site_db() aborts when NL capacity validation fails
- Data is correctly saved when NL capacity validation passes

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
