### PR TITLE
docs: document RUVNL site database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ We currently collect
 - BE: Solar PV forecast data (national and regional) from Elia Open Data API.
 - India (Rajasthan): Real-time solar and wind generation data from RUVNL (Rajasthan Urja Vikas Nigam Limited).
 
+### India – RUVNL (Rajasthan)
+
+The solar consumer supports **RUVNL (Rajasthan, India)** real-time generation data.
+
+- Both **solar and wind** generation are supported
+- Data is fetched via `solar-consumer`
+- Generation data can be saved directly to the **site_database**
+- Separate sites are created for solar and wind generation
+- No separate `ruvnl-consumer` service is required
+
+
 
 
 Here are the different sources of data, and which methods can be used to save the results
@@ -25,7 +36,7 @@ Here are the different sources of data, and which methods can be used to save th
 | Ned-nl forecast | 🇳🇱 | ✅ ||| ✅ |
 | Germany (ENTSOE) | 🇩🇪 |  ✅ ||| ✅ |
 | Elia Open Data | 🇧🇪 | ✅ |  |  |  |
-| RUVNL (Rajasthan SLDC) | 🇮🇳 | ✅ |  |  |  |
+| RUVNL (Rajasthan SLDC) | 🇮🇳 | ✅ |  |  | ✅ |
 
 
 ## Requirements
@@ -90,12 +101,12 @@ The package provides three main functionalities:
 
 - `DB_URL=postgresql://postgres:postgres@localhost:5432/neso_solar` : Database Configuration
 - `COUNTRY="gb"` : Country code for fetching data. Currently, other options are ["be", "ind_rajasthan", "nl"] 
-- `SAVE_METHOD="db"`: Ways to store the data. Currently other options are ["csv", "site-db"]
+- `SAVE_METHOD`: Ways to store the data. Options are ["db", "csv", "site-db"].  
+  `site-db` is supported for NL, DE, and India (RUVNL).
 - `CSV_DIR=None` : Directory to save CSV files if `SAVE_METHOD="csv"`.
 - `UK_PVLIVE_REGIME=in-day`: For UK PVLive, the regime. Can be "in-day" or "day-after"
 - `UK_PVLIVE_N_GSPS=342`: For UK PVLive, the amount of gsps we pull data for.
 - `UK_PVLIVE_BACKFILL_HOURS=2`: For UK PVLive, the amount of backfill hours we pull, when regime="in-day"
-- 
 
 ## Development
 


### PR DESCRIPTION
# Pull Request

## Description

This PR updates the README to document support for saving RUVNL (Rajasthan, India)
solar and wind generation data to the site database.

It clarifies that:
- RUVNL data supports both solar and wind generation
- Data can be saved using `SAVE_METHOD="site-db"`
- Separate sites are created for solar and wind generation
- The source table correctly reflects Site DB support

No code changes are included; this PR is documentation-only.

## How Has This Been Tested?

- [x] Yes

This change is documentation-only and does not affect runtime behaviour.
The README was manually reviewed to ensure it accurately reflects the
existing implementation.

- [ ] _Not applicable (no data processing changes)_

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable)
- [x] I have checked my code and corrected any misspellings
