### PR TITLE
gb: used installedcapacity_mwp to make capacity_kw

### DIFF
--- a/solar_consumer/data/fetch_gb_data.py
+++ b/solar_consumer/data/fetch_gb_data.py
@@ -150,15 +150,15 @@ def fetch_gb_data_historic(regime: str) -> pd.DataFrame:
         gsp_yield_df["pvlive_updated_utc"] = pd.to_datetime(gsp_yield_df["updated_gmt"])
         
         # Convert capacity to kW
-        gsp_yield_df["installedcapacity_kw"] = gsp_yield_df["installedcapacity_mwp"] * 1000
-        gsp_yield_df["capacity_kw"] = gsp_yield_df["capacity_mwp"] * 1000
-        
+        gsp_yield_df["capacity_kw"] = gsp_yield_df["installedcapacity_mwp"] * 1000
+        gsp_yield_df["capacity_no_degradation_kw"] = gsp_yield_df["capacity_mwp"] * 1000
+
         gsp_yield_df = gsp_yield_df[
             [
                 "solar_generation_kw",
                 "target_datetime_utc",
-                "installedcapacity_kw",
                 "capacity_kw",
+                "capacity_no_degradation_kw",
                 "pvlive_updated_utc",
             ]
         ]


### PR DESCRIPTION
# Pull Request

## Description

Fix for Uk capacity. 
We actually use the installedcapacity_mwp in our sytems internally as it the solar cpaiacty that pvlive used
https://github.com/openclimatefix/client-private/issues/242

## How Has This Been Tested?

- [x] CI tests
- [x] ran locally and checked that capacity was updated

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
