### PR TITLE
add installed capacity into metadata of location

### DIFF
--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -371,7 +371,7 @@ async def save_generation_to_data_platform(
         # this is specific to GB consumer at the moment
         if "capacity_no_degradation_kw" in updates_df.columns:
             metadata = format_metadata_from_dict(metadata=row.metadata)
-            metadata["capacity_no_degradation_watts"] = Value(number_value=int(row.capacity_no_degradation_kw*1_000))
+            metadata["capacity_no_degradation_kw"] = Value(number_value=int(row.capacity_no_degradation_kw))
             metadata = Struct(fields=metadata)
         else:
             metadata = None

--- a/tests/integration/test_save_to_data_platform.py
+++ b/tests/integration/test_save_to_data_platform.py
@@ -88,4 +88,4 @@ async def test_save_to_data_platform(client):
     get_location_response = await client.get_location(get_location_request)
     assert get_location_response.effective_capacity_watts == 2_000_000
     metadata_dict = get_location_response.metadata.to_dict()
-    assert metadata_dict["capacity_no_degradation_watts"]['numberValue'] == 2_200_000
+    assert metadata_dict["capacity_no_degradation_kw"]['numberValue'] == 2_200


### PR DESCRIPTION
# Pull Request

## Description

- Add `capacity_no_degradation_kw` into location metadata. 
- This will then be used by the quartz-api

Helps with https://github.com/openclimatefix/client-private/issues/258

## How Has This Been Tested?

- CI tests
- added a new test
- ran locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
