### PR TITLE
save generation values at night

### DIFF
--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -162,7 +162,8 @@ def fetch_nl_data(historic_or_forecast: str = "generation"):
     # set very small percentages to NaN to avoid huge capacity values
     all_data["capacity_kw"] = all_data["capacity (kW)"] / all_data["percentage"]
     small_percentage = all_data["percentage"] < 0.01
-    all_data.loc[small_percentage, "capacity_kw"] = np.nan
+    all_data['update_capacity'] = True
+    all_data.loc[small_percentage, "update_capacity"] = False
 
     # change region_id to integer, just to be safe
     all_data["region_id"] = all_data["region_id"].astype(int)

--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -162,7 +162,6 @@ def fetch_nl_data(historic_or_forecast: str = "generation"):
     all_data["capacity_kw"] = all_data["capacity (kW)"] / all_data["percentage"]
     small_percentage = all_data["percentage"] < 0.01
     all_data['update_capacity'] = True
-    all_data.loc[small_percentage, "update_capacity"] = False
     # flag that we should not update capacity and 
     # set capacity_kw to a default value (we need it to be something, not nan, 
     # otherwise generation values dont get saved)

--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -158,10 +158,10 @@ def fetch_nl_data(historic_or_forecast: str = "generation"):
     all_data = all_data.sort_values("validfrom (UTC)")
 
     # get the total site capacity and
-    # set very small percentages to NaN to avoid huge capacity values
+    # set very small percentages update_capacity=False
+    all_data['update_capacity'] = True
     all_data["capacity_kw"] = all_data["capacity (kW)"] / all_data["percentage"]
     small_percentage = all_data["percentage"] < 0.01
-    all_data['update_capacity'] = True
     # flag that we should not update capacity and 
     # set capacity_kw to a default value (we need it to be something, not nan, 
     # otherwise generation values dont get saved)

--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -2,7 +2,6 @@
 import os
 import requests
 from datetime import datetime, timedelta, timezone
-import numpy as np
 import pandas as pd
 import time
 import dotenv
@@ -164,6 +163,11 @@ def fetch_nl_data(historic_or_forecast: str = "generation"):
     small_percentage = all_data["percentage"] < 0.01
     all_data['update_capacity'] = True
     all_data.loc[small_percentage, "update_capacity"] = False
+    # flag that we should not update capacity and 
+    # set capacity_kw to a default value (we need it to be something, not nan, 
+    # otherwise generation values dont get saved)
+    all_data.loc[small_percentage, "update_capacity"] = False
+    all_data.loc[small_percentage, "capacity_kw"] = 1.0 
 
     # change region_id to integer, just to be safe
     all_data["region_id"] = all_data["region_id"].astype(int)

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -615,6 +615,11 @@ def get_update_capacity_df(df: pd.DataFrame) -> pd.DataFrame:
         ~np.isclose(current_cap, new_cap, atol=1_000_000, rtol=0)
     )
 
+    if "update_capacity" in df.columns:
+        # only update capacity if this is set to True
+        # we use this in NL for non-validated capacities
+        update_idx = np.logical_or(update_idx, df["update_capacity"])
+
     updates_df = (
         df.loc[update_idx]
         .sort_values(by="target_datetime_utc", ascending=False)

--- a/tests/unit/test_fetch_data.py
+++ b/tests/unit/test_fetch_data.py
@@ -202,7 +202,7 @@ def test_fetch_nl_data_small_percentage(mock_api, nl_mock_data_small_percentage)
     assert not df.empty
     assert "capacity (kW)" in df.columns
     assert "volume (kWh)" in df.columns
-    assert df["capacity_kw"].isna().all()
+    assert df["update_capacity"].all() == False
 
 def test_gb_historic_inday():
 

--- a/tests/unit/test_fetch_data.py
+++ b/tests/unit/test_fetch_data.py
@@ -202,7 +202,7 @@ def test_fetch_nl_data_small_percentage(mock_api, nl_mock_data_small_percentage)
     assert not df.empty
     assert "capacity (kW)" in df.columns
     assert "volume (kWh)" in df.columns
-    assert df["update_capacity"].all() == False
+    assert not df["update_capacity"].all()
 
 def test_gb_historic_inday():
 


### PR DESCRIPTION
# Pull Request

## Description

Currently no NL night time values are being saved. THis is becasue we have set the cpacity_kw to nan
This changes that, we use new collumn `update_capacity` as a flag to if we want to update the capacity, but we still save the  generation values

Will need to update #188 too, but wanted to keep it separate for the moment

## How Has This Been Tested?

- [x] Ci tests
- [x] ran locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
