### PR TITLE
Move hardcoded URLs to constants.py

### DIFF
--- a/solar_consumer/constants.py
+++ b/solar_consumer/constants.py
@@ -1,0 +1,30 @@
+# Belgium (Elia) API URLs
+BE_FORECAST_URL = (
+    "https://opendata.elia.be/api/explore/v2.1/"
+    "catalog/datasets/ods032/records"
+)
+BE_GENERATION_URL = (
+    "https://opendata.elia.be/api/explore/v2.1/"
+    "catalog/datasets/ods087/records"
+)
+
+# Germany (ENTSO-E) API URL
+DE_ENTSOE_URL = "https://web-api.tp.entsoe.eu/api"
+
+# Great Britain - NESO forecast API URL
+GB_NESO_FORECAST_URL = (
+    "https://api.neso.energy/api/3/action/datapackage_show"
+    "?id=embedded-wind-and-solar-forecasts"
+)
+
+# Great Britain - NESO datastore SQL API URL
+GB_NESO_DATASTORE_URL = "https://api.neso.energy/api/3/action/datastore_search_sql"
+
+# Great Britain - PVLive domain URL
+GB_PVLIVE_DOMAIN_URL = "api.pvlive.uk"
+
+# Netherlands (NED) API base URL
+NL_BASE_URL = "https://api.ned.nl/v1"
+
+# India - Rajasthan SLDC data URL
+IND_RAJASTHAN_URL = "http://sldc.rajasthan.gov.in/rrvpnl/read-sftp?type=overview"

--- a/solar_consumer/data/fetch_be_data.py
+++ b/solar_consumer/data/fetch_be_data.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta, timezone
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from solar_consumer.constants import BE_FORECAST_URL, BE_GENERATION_URL
+
 def _build_session() -> requests.Session:
     session = requests.Session()
 
@@ -21,15 +23,8 @@ def _build_session() -> requests.Session:
 
     return session
 
-BASE_URL_FORECAST = (
-    "https://opendata.elia.be/api/explore/v2.1/"
-    "catalog/datasets/ods032/records"
-)
-
-BASE_URL_GENERATION = (
-    "https://opendata.elia.be/api/explore/v2.1/"
-    "catalog/datasets/ods087/records"
-)
+BASE_URL_FORECAST = BE_FORECAST_URL
+BASE_URL_GENERATION = BE_GENERATION_URL
 
 REQUEST_LIMIT = 50
 

--- a/solar_consumer/data/fetch_de_data.py
+++ b/solar_consumer/data/fetch_de_data.py
@@ -6,6 +6,8 @@ import requests
 import xml.etree.ElementTree as ET
 from loguru import logger
 
+from solar_consumer.constants import DE_ENTSOE_URL
+
 # Load environment variables
 dotenv.load_dotenv()
 
@@ -31,7 +33,7 @@ def fetch_de_data(historic_or_forecast: str = "generation") -> pd.DataFrame:
     period_end = now.strftime("%Y%m%d%H%M")
 
     # Prepare request
-    url = "https://web-api.tp.entsoe.eu/api" # base url for api
+    url = DE_ENTSOE_URL
     API_KEY = os.getenv("ENTSOE_API_KEY", "") # api key from env vars, empty string if missing
     params = {
         "documentType": "A75",    # actual generation

--- a/solar_consumer/data/fetch_gb_data.py
+++ b/solar_consumer/data/fetch_gb_data.py
@@ -9,6 +9,8 @@ from datetime import datetime, timedelta, timezone
 
 from pvlive_api import PVLive
 
+from solar_consumer.constants import GB_NESO_FORECAST_URL, GB_PVLIVE_DOMAIN_URL
+
 
 def fetch_gb_data(historic_or_forecast: str = "forecast") -> pd.DataFrame:
     """
@@ -36,7 +38,7 @@ def fetch_gb_data_forecast() -> pd.DataFrame:
                       - `Datetime_GMT`: Combined date and time in UTC.
                       - `solar_forecast_kw`: Estimated solar forecast in kW.
     """
-    meta_url = "https://api.neso.energy/api/3/action/datapackage_show?id=embedded-wind-and-solar-forecasts"
+    meta_url = GB_NESO_FORECAST_URL
     response = urllib.request.urlopen(meta_url)
     data = json.loads(response.read().decode("utf-8"))
 
@@ -89,8 +91,7 @@ def fetch_gb_data_historic(regime: str) -> pd.DataFrame:
         - pvlive_updated_utc: timestamp of when pvlive last updated the data
     """
 
-    pvlive_domain_url = "api.pvlive.uk"
-    pvlive = PVLive(domain_url=pvlive_domain_url)
+    pvlive = PVLive(domain_url=GB_PVLIVE_DOMAIN_URL)
     # ignore these gsp ids from PVLive as they are no longer used
     ignore_gsp_ids = [5, 17, 41, 53, 75, 139, 140, 143, 157, 158, 163, 225, 257, 310]
 

--- a/solar_consumer/data/fetch_ind_rajasthan_data.py
+++ b/solar_consumer/data/fetch_ind_rajasthan_data.py
@@ -6,9 +6,11 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 import requests
 
+from solar_consumer.constants import IND_RAJASTHAN_URL
+
 log = logging.getLogger(__name__)
 
-DEFAULT_DATA_URL = "http://sldc.rajasthan.gov.in/rrvpnl/read-sftp?type=overview"
+DEFAULT_DATA_URL = IND_RAJASTHAN_URL
 
 
 def fetch_ind_rajasthan_data(

--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -8,11 +8,13 @@ import dotenv
 from loguru import logger
 from tqdm import tqdm
 
+from solar_consumer.constants import NL_BASE_URL
+
 # load .env variables
 dotenv.load_dotenv()
 
 # API base URL
-BASE_URL = "https://api.ned.nl/v1"
+BASE_URL = NL_BASE_URL
 
 # Get API credentials from environment variables
 API_KEY = os.getenv("APIKEY_NEDNL")

--- a/solar_consumer/fetch_data.py
+++ b/solar_consumer/fetch_data.py
@@ -13,6 +13,7 @@ from solar_consumer.data.fetch_gb_data import fetch_gb_data
 from solar_consumer.data.fetch_nl_data import fetch_nl_data
 from solar_consumer.data.fetch_de_data import fetch_de_data
 from solar_consumer.data.fetch_be_data import fetch_be_data
+from solar_consumer.constants import GB_NESO_DATASTORE_URL
 from solar_consumer.data.fetch_ind_rajasthan_data import fetch_ind_rajasthan_data
 
 
@@ -65,7 +66,7 @@ def fetch_data_using_sql(sql_query: str) -> pd.DataFrame:
                       - `target_datetime_utc`: Combined date and time in UTC.
                       - `solar_generation_kw`: Estimated solar forecast in kW.
     """
-    base_url = "https://api.neso.energy/api/3/action/datastore_search_sql"
+    base_url = GB_NESO_DATASTORE_URL
     encoded_query = urllib.parse.quote(sql_query)
     url = f"{base_url}?sql={encoded_query}"
 


### PR DESCRIPTION
Closes #172

# Pull Request

## Description

Move hardcoded external API URLs into a central constants module and update fetchers to use those constants.

Fixes #172

