### PR TITLE
fix: don't default capacity_kw to 1.0 for low-percentage values

### DIFF
--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -166,7 +166,6 @@ def fetch_nl_data(historic_or_forecast: str = "generation"):
     # set capacity_kw to a default value (we need it to be something, not nan, 
     # otherwise generation values dont get saved)
     all_data.loc[small_percentage, "update_capacity"] = False
-    all_data.loc[small_percentage, "capacity_kw"] = 1.0 
 
     # change region_id to integer, just to be safe
     all_data["region_id"] = all_data["region_id"].astype(int)

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -305,7 +305,7 @@ async def save_generation_to_data_platform(
             locations_df
             .set_index("join_key")
             .join(
-                data_df.query("capacity_kw>0").set_index("join_key"),
+                data_df.query("capacity_kw!=0").set_index("join_key"),
                 on="join_key",
                 how="inner",
                 lsuffix="_loc",
@@ -313,7 +313,7 @@ async def save_generation_to_data_platform(
             .assign(
                 new_effective_capacity_watts=lambda df: (
                     df["capacity_kw"] * 1000
-                ).astype(int)
+                )
             )
             .assign(target_datetime_utc=lambda df: pd.to_datetime(df["target_datetime_utc"]))
         )
@@ -322,7 +322,7 @@ async def save_generation_to_data_platform(
 
     if joined_df.empty:
         # Check if the input data was empty or had no valid capacity data
-        has_valid_capacity_data = not data_df.empty and (data_df["capacity_kw"] > 0).any()
+        has_valid_capacity_data = not data_df.empty and (data_df["capacity_kw"] != 0).any()
         
         if data_df.empty or not has_valid_capacity_data:
             # Empty input or all zero-capacity data - this is expected, return silently
@@ -366,7 +366,7 @@ async def save_generation_to_data_platform(
         req = dp.UpdateLocationRequest(
             location_uuid=lid,
             energy_source=dp.EnergySource.SOLAR,
-            new_effective_capacity_watts=new_cap,
+            new_effective_capacity_watts=int(new_cap),
             valid_from_utc=t,
             new_metadata=metadata,
         )


### PR DESCRIPTION
# Pull Request

## Description

Removed default default capacity_kw value of 1, if there is low-percentage

Fixes #197

## How Has This Been Tested?

Tested with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
