### PR TITLE
when updating capacity, only consider the last timestamp for each loc…

### DIFF
--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -6,7 +6,6 @@ https://github.com/openclimatefix/data-platform
 
 import datetime
 from dp_sdk.ocf import dp
-import numpy as np
 import pandas as pd
 
 import asyncio
@@ -603,19 +602,22 @@ def format_metadata_from_dict(metadata):
 def get_update_capacity_df(df: pd.DataFrame) -> pd.DataFrame:
     """Get the rows that need to be updated based on capacity change."""
 
-    current_cap = df["effective_capacity_watts"]
-    new_cap = df["new_effective_capacity_watts"]
-
-    update_idx = current_cap != new_cap
+    # lets only consider non nans values
+    df = df[~df["new_effective_capacity_watts"].isna()]
 
     if "update_capacity" in df.columns:
         # only update capacity if this is set to True
         # we use this in NL for non-validated capacities
-        update_idx = np.logical_and(update_idx, df["update_capacity"])
+        df = df[df['update_capacity']]
 
-    # just to double check, lets make sure we dont update to any nan values
-    update_idx = np.logical_and(update_idx, ~new_cap.isna())
+    # lets make sure we use the latest timestamp for each location_uuid
+    df = df.sort_values(by="target_datetime_utc", ascending=False).groupby("location_uuid").head(1)
 
+    current_cap = df["effective_capacity_watts"]
+    new_cap = df["new_effective_capacity_watts"]
+
+    update_idx = current_cap != new_cap
+    
     updates_df = (
         df.loc[update_idx]
         .sort_values(by="target_datetime_utc", ascending=False)

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -616,8 +616,9 @@ def get_update_capacity_df(df: pd.DataFrame) -> pd.DataFrame:
     current_cap = df["effective_capacity_watts"]
     new_cap = df["new_effective_capacity_watts"]
 
-    update_idx = current_cap != new_cap
-    
+    # only update if the difference is more than one
+    update_idx = (current_cap - new_cap).abs() >= 1
+
     updates_df = (
         df.loc[update_idx]
         .sort_values(by="target_datetime_utc", ascending=False)

--- a/tests/integration/test_save_to_data_platform.py
+++ b/tests/integration/test_save_to_data_platform.py
@@ -198,16 +198,22 @@ def test_get_update_capacity_df():
     # 0. is the same
     test_1 = {'effective_capacity_watts': 1, 
                     'new_effective_capacity_watts': 1, 
-                    'target_datetime_utc': pd.to_datetime("2026-03-26T12:00:00Z")}
+                    'target_datetime_utc': pd.to_datetime("2026-03-26T12:00:00Z"),
+                    'location_uuid': 'location_1'
+                   }
     # 1. is an increase
     test_2 = {'effective_capacity_watts': 2, 
                     'new_effective_capacity_watts': 4, 
-                    'target_datetime_utc': pd.to_datetime("2026-03-26T12:30:00Z")}
+                    'target_datetime_utc': pd.to_datetime("2026-03-26T12:30:00Z"),
+                    'location_uuid': 'location_2'
+                   }
     # 2. is a decreasue
     test_3 = {'effective_capacity_watts': 3, 
                     'new_effective_capacity_watts': 2, 
-                    'target_datetime_utc': pd.to_datetime("2026-03-26T13:00:00Z")}
-    
+                    'target_datetime_utc': pd.to_datetime("2026-03-26T13:00:00Z"),
+                    'location_uuid': 'location_3'
+                   }
+
     df = pd.DataFrame([test_1, test_2, test_3])
     updates_df = get_update_capacity_df(df)
     assert not updates_df.empty


### PR DESCRIPTION
…ation

# Pull Request

## Description

- This makes sure we only consider updating the capacity on the last datapoint. Before we were considering all, and this was causing a problem when updating values around when the sun goes down
- only do updates if the amount changed is larged than 1 watts, otherwise dataplatform doesnt save it

Helps with https://github.com/openclimatefix/solar-consumer/issues/199

## How Has This Been Tested?

- [x] CI tests
- [ ] Tried to run locally on dev, but there was already an updated value for the timestamp. However I think that value was slightly wrong (using a past one), and if this is deployed then we wont have this problem any more

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
