### PR TITLE
chore: update GB_PVLIVE_DOMAIN_URL to solar.sheffield.ac.uk API endpoint

### DIFF
--- a/solar_consumer/constants.py
+++ b/solar_consumer/constants.py
@@ -21,7 +21,7 @@ GB_NESO_FORECAST_URL = (
 GB_NESO_DATASTORE_URL = "https://api.neso.energy/api/3/action/datastore_search_sql"
 
 # Great Britain - PVLive domain URL
-GB_PVLIVE_DOMAIN_URL = "api.pvlive.uk"
+GB_PVLIVE_DOMAIN_URL = "api.solar.sheffield.ac.uk"
 
 # Netherlands (NED) API base URL
 NL_BASE_URL = "https://api.ned.nl/v1"


### PR DESCRIPTION
# Pull Request

## Description

This PR reverts the `GB_PVLIVE_DOMAIN_URL` in `solar_consumer/constants.py` to the legacy Sheffield domain: `api.solar.sheffield.ac.uk`. This change ensures compatibility with systems or environments that still rely on the legacy PVLive API endpoint for Great Britain solar data.

Fixes #

## How Has This Been Tested?

- [x] **Connectivity Check:** Verified that the application can successfully connect to the legacy Sheffield URL.
- [x] **Data Fetching:** Confirmed that solar generation data is correctly retrieved from the legacy domain in the historic data fetch flow.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
