### PR TITLE
chore: update GB_PVLIVE_DOMAIN_URL to api.pvlive.uk

### DIFF
--- a/solar_consumer/constants.py
+++ b/solar_consumer/constants.py
@@ -21,7 +21,7 @@ GB_NESO_FORECAST_URL = (
 GB_NESO_DATASTORE_URL = "https://api.neso.energy/api/3/action/datastore_search_sql"
 
 # Great Britain - PVLive domain URL
-GB_PVLIVE_DOMAIN_URL = "api.solar.sheffield.ac.uk"
+GB_PVLIVE_DOMAIN_URL = "api.pvlive.uk"
 
 # Netherlands (NED) API base URL
 NL_BASE_URL = "https://api.ned.nl/v1"


### PR DESCRIPTION
# Pull Request

## Description

Update base_url from `api.solar.sheffield.ac.uk` to `api.pvlive.uk`

[issue](https://github.com/openclimatefix/solar-consumer/issues/209)

## How Has This Been Tested?

Tested locally and verified through the logs that it is able to fetch the generation data from the updated URL.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
