### PR TITLE
Add UK_PVLIVE_DOMAIN_URL for configurable PVLive API domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The package provides three main functionalities:
 - `UK_PVLIVE_REGIME=in-day`: For UK PVLive, the regime. Can be "in-day" or "day-after"
 - `UK_PVLIVE_N_GSPS=342`: For UK PVLive, the amount of gsps we pull data for.
 - `UK_PVLIVE_BACKFILL_HOURS=2`: For UK PVLive, the amount of backfill hours we pull, when regime="in-day"
+- `UK_PVLIVE_DOMAIN_URL`: For UK PVLive, the domain URL to fetch data from. Defaults to "api.pvlive.uk"
 - `NL_POTENTIAL_GENERATION`: boolen, to create and save a potential solar generation
 - `APIKEY_ENTSOE`: The ENSTOE api key, needed for get DA prices, used for NL potential generation. 
 

--- a/solar_consumer/data/fetch_gb_data.py
+++ b/solar_consumer/data/fetch_gb_data.py
@@ -90,8 +90,8 @@ def fetch_gb_data_historic(regime: str) -> pd.DataFrame:
         - regime: either 'in-day' or 'day-after'
         - pvlive_updated_utc: timestamp of when pvlive last updated the data
     """
-
-    pvlive = PVLive(domain_url=GB_PVLIVE_DOMAIN_URL)
+    gb_pvlive_domain_url = os.getenv("GB_PVLIVE_DOMAIN_URL", GB_PVLIVE_DOMAIN_URL)
+    pvlive = PVLive(domain_url=gb_pvlive_domain_url)
     # ignore these gsp ids from PVLive as they are no longer used
     ignore_gsp_ids = [4, 5, 17, 41, 53, 56, 75, 122, 139, 140, 143, 157, 158, 163, 225, 257, 310]
 


### PR DESCRIPTION
# Pull Request

## Description

- Read gb_pvlive_domain_url from the environment variables instead of constants.

- Updated the README file to include the new environment variable UK_PVLIVE_DOMAIN_URL

[issue](https://github.com/openclimatefix/solar-consumer/issues/209) 

Fixes #

## How Has This Been Tested?

- Verified by adding the logs it takes the URL which is there in the Env not in constants
- Verified in the logs when the correct URL is added in the Env it starts fetching the Generation data

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
