### PR TITLE
feat: implement observation deduplication and update valid_from_utc t…

### DIFF
--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -206,6 +206,72 @@ async def _create_locations_from_csv(
     )
 
 
+async def _filter_existing_observations(
+    joined_df: pd.DataFrame,
+    data_df: pd.DataFrame,
+    client: dp.DataPlatformDataServiceStub,
+    config: dict,
+    country: str,
+) -> pd.DataFrame:
+    """Filter out observations that already exist in the data platform."""
+    if joined_df.empty:
+        return joined_df
+
+    # Get the locations
+    location_uuids = joined_df["location_uuid"].unique()
+    
+    # Get the min and max timestamps
+    min_timestamp = joined_df["target_datetime_utc"].min()
+    max_timestamp = datetime.datetime.now(datetime.timezone.utc)
+
+    # Determine observer name based on country
+    observer_name = config["observer_name"]
+    if observer_name is None:  # GB needs regime from data
+        regime: str = data_df["regime"].values[0]
+        observer_name = f"pvlive_{regime.replace('-', '_')}"
+
+    # Read generation values from data platform, in parallel for all locations.
+    read_observations_tasks = []
+    for lid in location_uuids:
+        req = dp.GetObservationsAsTimeseriesRequest(
+            location_uuid=lid,
+            observer_name=observer_name,
+            energy_source=dp.EnergySource.SOLAR,
+            time_window=dp.TimeWindow(
+                start_timestamp_utc=min_timestamp,
+                end_timestamp_utc=max_timestamp
+            )
+        )
+        read_observations_tasks.append(asyncio.create_task(client.get_observations_as_timeseries(req)))
+
+    if len(read_observations_tasks) > 0:
+        logger.info(f"reading observations for {len(read_observations_tasks)} {country.upper()} locations")
+        await _execute_async_tasks(read_observations_tasks, ignore_exceptions=True)
+
+    # Compare timestamps already in the data platform
+    existing_observations = []
+    for task in read_observations_tasks:
+        try:
+            existing_observations.extend(task.result().values)
+        except Exception as e:
+            logger.error(f"Failed to read observations for location_uuid {task.location_uuid}: {e}")
+
+    existing_timestamps = {obs.timestamp_utc for obs in existing_observations}
+
+    # if any timestamps already in the data-platform, remove from data in app
+    idx = joined_df["target_datetime_utc"].isin(existing_timestamps)
+    if idx.any():
+        location_uuids = joined_df.loc[idx, "location_uuid"].unique()
+        logger.warning(
+            f"Found {idx.sum()} values already existing in data platform "
+            f"for location_uuid {location_uuids}. "
+            "These values will be dropped."
+        )
+        joined_df = joined_df[~idx]
+
+    return joined_df
+
+
 async def save_generation_to_data_platform(
     data_df: pd.DataFrame, client: dp.DataPlatformDataServiceStub, config_name: str = "gb"
 ) -> None:
@@ -383,7 +449,7 @@ async def save_generation_to_data_platform(
             location_uuid=lid,
             energy_source=dp.EnergySource.SOLAR,
             new_effective_capacity_watts=int(new_cap),
-            valid_from_utc=t,
+            valid_from_utc=datetime.datetime.now(datetime.timezone.utc),
             new_metadata=metadata,
         )
         tasks.append(asyncio.create_task(client.update_location(req)))
@@ -405,6 +471,15 @@ async def save_generation_to_data_platform(
                         for location_uuid {location_uuids}. \
                         These values will be dropped.")
         joined_df = joined_df[~idx]
+
+    # Filter out observations that already exist in the data platform
+    joined_df = await _filter_existing_observations(
+        joined_df=joined_df,
+        data_df=data_df,
+        client=client,
+        config=config,
+        country=country,
+    )
 
 
     observations_by_loc: dict[str, list[dp.CreateObservationsRequestValue]] = defaultdict(list)

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -250,11 +250,11 @@ async def _filter_existing_observations(
 
     # Compare timestamps already in the data platform
     existing_observations = []
-    for task in read_observations_tasks:
+    for lid, task in zip(location_uuids, read_observations_tasks):
         try:
             existing_observations.extend(task.result().values)
         except Exception as e:
-            logger.error(f"Failed to read observations for location_uuid {task.location_uuid}: {e}")
+            logger.error(f"Failed to read observations for location_uuid {lid}: {e}")
 
     existing_timestamps = {obs.timestamp_utc for obs in existing_observations}
 

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -211,7 +211,6 @@ async def _filter_existing_observations(
     regime: str | None,
     client: dp.DataPlatformDataServiceStub,
     config: dict,
-    country: str,
 ) -> pd.DataFrame:
     """Filter out observations that already exist in the data platform."""
     if joined_df.empty:
@@ -244,7 +243,7 @@ async def _filter_existing_observations(
         read_observations_tasks.append(asyncio.create_task(client.get_observations_as_timeseries(req)))
 
     if len(read_observations_tasks) > 0:
-        logger.info(f"reading observations for {len(read_observations_tasks)} {country.upper()} locations")
+        logger.info(f"reading observations for {len(read_observations_tasks)}  locations")
         await _execute_async_tasks(read_observations_tasks, ignore_exceptions=True)
 
     # Compare timestamps already in the data platform
@@ -478,7 +477,6 @@ async def save_generation_to_data_platform(
         regime=regime,
         client=client,
         config=config,
-        country=country,
     )
 
 

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -449,7 +449,7 @@ async def save_generation_to_data_platform(
             location_uuid=lid,
             energy_source=dp.EnergySource.SOLAR,
             new_effective_capacity_watts=int(new_cap),
-            valid_from_utc=datetime.datetime.now(datetime.timezone.utc),
+            valid_from_utc=t,
             new_metadata=metadata,
         )
         tasks.append(asyncio.create_task(client.update_location(req)))

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -208,7 +208,7 @@ async def _create_locations_from_csv(
 
 async def _filter_existing_observations(
     joined_df: pd.DataFrame,
-    data_df: pd.DataFrame,
+    regime: str | None,
     client: dp.DataPlatformDataServiceStub,
     config: dict,
     country: str,
@@ -227,7 +227,6 @@ async def _filter_existing_observations(
     # Determine observer name based on country
     observer_name = config["observer_name"]
     if observer_name is None:  # GB needs regime from data
-        regime: str = data_df["regime"].values[0]
         observer_name = f"pvlive_{regime.replace('-', '_')}"
 
     # Read generation values from data platform, in parallel for all locations.
@@ -473,9 +472,10 @@ async def save_generation_to_data_platform(
         joined_df = joined_df[~idx]
 
     # Filter out observations that already exist in the data platform
+    regime = data_df["regime"].values[0] if "regime" in data_df.columns else None
     joined_df = await _filter_existing_observations(
         joined_df=joined_df,
-        data_df=data_df,
+        regime=regime,
         client=client,
         config=config,
         country=country,

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -208,9 +208,8 @@ async def _create_locations_from_csv(
 
 async def _filter_existing_observations(
     joined_df: pd.DataFrame,
-    regime: str | None,
     client: dp.DataPlatformDataServiceStub,
-    config: dict,
+    observer_name: str,
 ) -> pd.DataFrame:
     """Filter out observations that already exist in the data platform."""
     if joined_df.empty:
@@ -222,11 +221,6 @@ async def _filter_existing_observations(
     # Get the min and max timestamps
     min_timestamp = joined_df["target_datetime_utc"].min()
     max_timestamp = datetime.datetime.now(datetime.timezone.utc)
-
-    # Determine observer name based on country
-    observer_name = config["observer_name"]
-    if observer_name is None:  # GB needs regime from data
-        observer_name = f"pvlive_{regime.replace('-', '_')}"
 
     # Read generation values from data platform, in parallel for all locations.
     read_observations_tasks = []
@@ -456,6 +450,12 @@ async def save_generation_to_data_platform(
         logger.info(f"updating {len(tasks)} {country.upper()} location capacities")
         # NL was previously ignoring these exceptions
         await _execute_async_tasks(tasks, ignore_exceptions=True)
+    
+    # Determine observer name based on country
+    observer_name = config["observer_name"]
+    if observer_name is None:  # GB needs regime from data
+        regime: str = data_df["regime"].values[0]
+        observer_name = f"pvlive_{regime.replace('-', '_')}"
 
     # 3. Generate the CreateObservationRequest objects from the DataFrame.
 
@@ -471,12 +471,10 @@ async def save_generation_to_data_platform(
         joined_df = joined_df[~idx]
 
     # Filter out observations that already exist in the data platform
-    regime = data_df["regime"].values[0] if "regime" in data_df.columns else None
     joined_df = await _filter_existing_observations(
         joined_df=joined_df,
-        regime=regime,
         client=client,
-        config=config,
+        observer_name=observer_name,
     )
 
 
@@ -490,11 +488,7 @@ async def save_generation_to_data_platform(
             dp.CreateObservationsRequestValue(timestamp_utc=t, value_watts=val)
         )
 
-    # Determine observer name based on country
-    observer_name = config["observer_name"]
-    if observer_name is None:  # GB needs regime from data
-        regime: str = data_df["regime"].values[0]
-        observer_name = f"pvlive_{regime.replace('-', '_')}"
+    
 
     tasks = [
         asyncio.create_task(

--- a/tests/unit/test_mixed_country_isolation.py
+++ b/tests/unit/test_mixed_country_isolation.py
@@ -66,6 +66,9 @@ class TestMixedCountryHandling(unittest.IsolatedAsyncioTestCase):
         client_mock.list_observers = AsyncMock(return_value=dp.ListObserversResponse(observers=[]))
         client_mock.create_observer = AsyncMock()
         client_mock.create_location = AsyncMock()
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=[])
+        )
 
         # Execute: Try to save data for NL
         nl_input_df = pd.DataFrame({

--- a/tests/unit/test_save_forecast.py
+++ b/tests/unit/test_save_forecast.py
@@ -250,6 +250,9 @@ class TestSaveGenerationToDataPlatform(unittest.IsolatedAsyncioTestCase):
             client_mock.create_observations = AsyncMock()
             client_mock.list_observers = AsyncMock(side_effect=mock_list_observers)
             client_mock.create_observer = AsyncMock()
+            client_mock.get_observations_as_timeseries = AsyncMock(
+                return_value=dp.GetObservationsAsTimeseriesResponse(values=[])
+            )
 
             with self.subTest(case.name):
                 if not case.should_error:
@@ -416,6 +419,9 @@ class TestSaveGenerationToDataPlatform(unittest.IsolatedAsyncioTestCase):
             client_mock.list_observers = AsyncMock(side_effect=mock_list_observers)
             client_mock.create_observer = AsyncMock()
             client_mock.create_location = AsyncMock()
+            client_mock.get_observations_as_timeseries = AsyncMock(
+                return_value=dp.GetObservationsAsTimeseriesResponse(values=[])
+            )
 
             with self.subTest(case.name):
                 if not case.should_error:
@@ -497,6 +503,9 @@ class TestSaveGenerationToDataPlatform(unittest.IsolatedAsyncioTestCase):
         client_mock.create_observations = AsyncMock()
         client_mock.list_observers = AsyncMock(side_effect=mock_list_observers)
         client_mock.create_observer = AsyncMock()
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=[])
+        )
 
         input_df = pd.DataFrame({
             "region_id": [0],

--- a/tests/unit/test_save_forecast.py
+++ b/tests/unit/test_save_forecast.py
@@ -2,6 +2,8 @@ from solar_consumer.save.save_site_database import save_generation_to_site_db, s
 from solar_consumer.save.save_data_platform import save_generation_to_data_platform
 from pvsite_datamodel.sqlmodels import GenerationSQL, ForecastSQL, ForecastValueSQL, LocationSQL
 import pandas as pd
+from solar_consumer.save.save_data_platform import _filter_existing_observations
+
 
 import unittest
 from unittest.mock import AsyncMock, patch
@@ -545,3 +547,162 @@ def test_save_generation_to_site_db_ind_rajasthan(db_site_session):
     site_names = sorted([site.client_location_name for site in sites])
 
     assert site_names == ["runvl_solar_site", "runvl_wind_site"]
+
+
+class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for _filter_existing_observations (GB-specific)."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_joined_df(self, location_uuids: list[str], timestamps: list) -> pd.DataFrame:
+        """Return a minimal joined_df with one row per (location_uuid, timestamp)."""
+        rows = []
+        for lid in location_uuids:
+            for ts in timestamps:
+                rows.append({"location_uuid": lid, "target_datetime_utc": pd.Timestamp(ts)})
+        return pd.DataFrame(rows)
+
+    def _gb_config(self) -> dict:
+        return {"observer_name": None}
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_empty_joined_df_returns_immediately(self, client_mock):
+        """An empty joined_df must be returned as-is without any client calls."""
+
+        result = await _filter_existing_observations(
+            joined_df=pd.DataFrame(),
+            regime=None,
+            client=client_mock,
+            config=self._gb_config(),
+            country="gb",
+        )
+
+        self.assertTrue(result.empty)
+        client_mock.get_observations_as_timeseries.assert_not_called()
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_no_existing_observations_returns_full_df(self, client_mock):
+        """When the data platform returns no observations, the full df is returned unchanged."""
+
+        lid = str(uuid.uuid4())
+        joined_df = self._make_joined_df([lid], ["2024-01-01T00:00:00", "2024-01-01T01:00:00"])
+
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=[])
+        )
+
+        result = await _filter_existing_observations(
+            joined_df=joined_df,
+            regime="in-day",
+            client=client_mock,
+            config=self._gb_config(),
+            country="gb",
+        )
+
+        self.assertEqual(len(result), len(joined_df))
+        client_mock.get_observations_as_timeseries.assert_called_once()
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_all_observations_already_exist_returns_empty(self, client_mock):
+        """When every timestamp already exists in the data platform, the result is empty."""
+
+        lid = str(uuid.uuid4())
+        ts1 = pd.Timestamp("2024-01-01T00:00:00", tz="UTC")
+        ts2 = pd.Timestamp("2024-01-01T01:00:00", tz="UTC")
+        joined_df = self._make_joined_df([lid], [ts1, ts2])
+
+        existing = [
+            dp.GetObservationsAsTimeseriesResponseValue(timestamp_utc=ts1, value_fraction=0.1, effective_capacity_watts=1_000_000),
+            dp.GetObservationsAsTimeseriesResponseValue(timestamp_utc=ts2, value_fraction=0.2, effective_capacity_watts=1_000_000),
+        ]
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=existing)
+        )
+
+        result = await _filter_existing_observations(
+            joined_df=joined_df,
+            regime="in-day",
+            client=client_mock,
+            config=self._gb_config(),
+            country="gb",
+        )
+
+        self.assertTrue(result.empty)
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_partial_overlap_drops_only_duplicates(self, client_mock):
+        """Only the timestamps already in the data platform are dropped."""
+
+        lid = str(uuid.uuid4())
+        ts_existing = pd.Timestamp("2024-01-01T00:00:00", tz="UTC")
+        ts_new = pd.Timestamp("2024-01-01T01:00:00", tz="UTC")
+        joined_df = self._make_joined_df([lid], [ts_existing, ts_new])
+
+        existing = [
+            dp.GetObservationsAsTimeseriesResponseValue(timestamp_utc=ts_existing, value_fraction=0.1, effective_capacity_watts=1_000_000),
+        ]
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=existing)
+        )
+
+        result = await _filter_existing_observations(
+            joined_df=joined_df,
+            regime="in-day",
+            client=client_mock,
+            config=self._gb_config(),
+            country="gb",
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result["target_datetime_utc"].iloc[0], ts_new)
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_regime_derives_correct_observer_name(self, client_mock):
+        """The observer name must be derived from the regime string (in-day → pvlive_in_day)."""
+
+        lid = str(uuid.uuid4())
+        joined_df = self._make_joined_df([lid], ["2024-01-01T00:00:00"])
+
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=[])
+        )
+
+        await _filter_existing_observations(
+            joined_df=joined_df,
+            regime="in-day",
+            client=client_mock,
+            config=self._gb_config(),
+            country="gb",
+        )
+
+        req: dp.GetObservationsAsTimeseriesRequest = (
+            client_mock.get_observations_as_timeseries.call_args.args[0]
+        )
+        self.assertEqual(req.observer_name, "pvlive_in_day")
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_multiple_locations_each_queried(self, client_mock):
+        """One get_observations_as_timeseries call is made per unique location_uuid."""
+
+        lids = [str(uuid.uuid4()) for _ in range(3)]
+        joined_df = self._make_joined_df(lids, ["2024-01-01T00:00:00"])
+
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=[])
+        )
+
+        await _filter_existing_observations(
+            joined_df=joined_df,
+            regime="day-after",
+            client=client_mock,
+            config=self._gb_config(),
+            country="gb",
+        )
+
+        self.assertEqual(client_mock.get_observations_as_timeseries.call_count, 3)

--- a/tests/unit/test_save_forecast.py
+++ b/tests/unit/test_save_forecast.py
@@ -550,7 +550,7 @@ def test_save_generation_to_site_db_ind_rajasthan(db_site_session):
 
 
 class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
-    """Unit tests for _filter_existing_observations (GB-specific)."""
+    """Unit tests for _filter_existing_observations."""
 
     # ------------------------------------------------------------------
     # Helpers
@@ -564,9 +564,6 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
                 rows.append({"location_uuid": lid, "target_datetime_utc": pd.Timestamp(ts)})
         return pd.DataFrame(rows)
 
-    def _gb_config(self) -> dict:
-        return {"observer_name": None}
-
     # ------------------------------------------------------------------
     # Tests
     # ------------------------------------------------------------------
@@ -577,9 +574,8 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
 
         result = await _filter_existing_observations(
             joined_df=pd.DataFrame(),
-            regime=None,
             client=client_mock,
-            config=self._gb_config(),
+            observer_name="pvlive_in_day",
         )
 
         self.assertTrue(result.empty)
@@ -598,9 +594,8 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
 
         result = await _filter_existing_observations(
             joined_df=joined_df,
-            regime="in-day",
             client=client_mock,
-            config=self._gb_config(),
+            observer_name="pvlive_in_day",
         )
 
         self.assertEqual(len(result), len(joined_df))
@@ -625,9 +620,8 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
 
         result = await _filter_existing_observations(
             joined_df=joined_df,
-            regime="in-day",
             client=client_mock,
-            config=self._gb_config(),
+            observer_name="pvlive_in_day",
         )
 
         self.assertTrue(result.empty)
@@ -650,17 +644,16 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
 
         result = await _filter_existing_observations(
             joined_df=joined_df,
-            regime="in-day",
             client=client_mock,
-            config=self._gb_config(),
+            observer_name="pvlive_in_day",
         )
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result["target_datetime_utc"].iloc[0], ts_new)
 
     @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
-    async def test_regime_derives_correct_observer_name(self, client_mock):
-        """The observer name must be derived from the regime string (in-day → pvlive_in_day)."""
+    async def test_observer_name_passed_through_to_request(self, client_mock):
+        """The observer_name is passed directly to the GetObservationsAsTimeseriesRequest."""
 
         lid = str(uuid.uuid4())
         joined_df = self._make_joined_df([lid], ["2024-01-01T00:00:00"])
@@ -671,15 +664,36 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
 
         await _filter_existing_observations(
             joined_df=joined_df,
-            regime="in-day",
             client=client_mock,
-            config=self._gb_config(),
+            observer_name="pvlive_in_day",
         )
 
         req: dp.GetObservationsAsTimeseriesRequest = (
             client_mock.get_observations_as_timeseries.call_args.args[0]
         )
         self.assertEqual(req.observer_name, "pvlive_in_day")
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_day_after_observer_name_passed_through_to_request(self, client_mock):
+        """The observer_name 'pvlive_day_after' is passed directly to the request."""
+
+        lid = str(uuid.uuid4())
+        joined_df = self._make_joined_df([lid], ["2024-01-01T00:00:00"])
+
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=[])
+        )
+
+        await _filter_existing_observations(
+            joined_df=joined_df,
+            client=client_mock,
+            observer_name="pvlive_day_after",
+        )
+
+        req: dp.GetObservationsAsTimeseriesRequest = (
+            client_mock.get_observations_as_timeseries.call_args.args[0]
+        )
+        self.assertEqual(req.observer_name, "pvlive_day_after")
 
     @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
     async def test_multiple_locations_each_queried(self, client_mock):
@@ -694,9 +708,8 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
 
         await _filter_existing_observations(
             joined_df=joined_df,
-            regime="day-after",
             client=client_mock,
-            config=self._gb_config(),
+            observer_name="pvlive_day_after",
         )
 
         self.assertEqual(client_mock.get_observations_as_timeseries.call_count, 3)

--- a/tests/unit/test_save_forecast.py
+++ b/tests/unit/test_save_forecast.py
@@ -580,7 +580,6 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
             regime=None,
             client=client_mock,
             config=self._gb_config(),
-            country="gb",
         )
 
         self.assertTrue(result.empty)
@@ -602,7 +601,6 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
             regime="in-day",
             client=client_mock,
             config=self._gb_config(),
-            country="gb",
         )
 
         self.assertEqual(len(result), len(joined_df))
@@ -630,7 +628,6 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
             regime="in-day",
             client=client_mock,
             config=self._gb_config(),
-            country="gb",
         )
 
         self.assertTrue(result.empty)
@@ -656,7 +653,6 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
             regime="in-day",
             client=client_mock,
             config=self._gb_config(),
-            country="gb",
         )
 
         self.assertEqual(len(result), 1)
@@ -678,7 +674,6 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
             regime="in-day",
             client=client_mock,
             config=self._gb_config(),
-            country="gb",
         )
 
         req: dp.GetObservationsAsTimeseriesRequest = (
@@ -702,7 +697,6 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
             regime="day-after",
             client=client_mock,
             config=self._gb_config(),
-            country="gb",
         )
 
         self.assertEqual(client_mock.get_observations_as_timeseries.call_count, 3)


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces an observation filtering mechanism in `save_data_platform.py` to prevent writing duplicate observations to the Data Platform.

Previously, all incoming generation records were created as new observations regardless of whether they already existed in the Data Platform. Now, the application first queries the Data Platform in parallel for all target locations to fetch existing observations within the current target time window, dropping any data rows whose timestamps already exist on the platform.

Additionally, the `valid_from_utc` timestamp for updating location capacities has been updated to the current time (`datetime.datetime.now(datetime.timezone.utc)`) rather than using the historical target time, aligning capacity validity with the actual update time.


Issue #209 

Fixes #

## How Has This Been Tested?

The changes have been verified by running the solar-consumer application locally against the dev Data Platform and confirming that duplicate observations are successfully identified, logged as dropped, and skipped during the save operation.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
