### PR TITLE
feat: process GB generation data by individual GSP IDs to improve err…

### DIFF
--- a/solar_consumer/app.py
+++ b/solar_consumer/app.py
@@ -139,7 +139,23 @@ async def app(
                     await save_forecasts_to_data_platform(data_df=data, client=client, model_tag=model_tag, model_version=__version__, init_time_utc=t0.to_pydatetime(), country=country)
                 else:
                     logger.info("Saving generation data to the Data Platform.")
-                    await save_generation_to_data_platform(data_df=data, client=client, config_name=country)
+                    if country == "gb" and "gsp_id" in data.columns:
+                        # Process each GSP location individually so that a failure or missing
+                        # location data for one GSP does not block all others.
+                        gsp_ids = data["gsp_id"].unique()
+                        logger.info(f"Saving GB generation data for {len(gsp_ids)} GSP locations one by one.")
+                        for gsp_id in gsp_ids:
+                            gsp_data = data[data["gsp_id"] == gsp_id].copy()
+                            try:
+                                await save_generation_to_data_platform(
+                                    data_df=gsp_data, client=client, config_name=country
+                                )
+                            except Exception as e:
+                                logger.error(
+                                    f"Failed to save generation data for gsp_id={gsp_id}: {e}"
+                                )
+                    else:
+                        await save_generation_to_data_platform(data_df=data, client=client, config_name=country)
 
                     # special save for Ned NL no curtailment
                     # we might want to make this more generic a bit later

--- a/solar_consumer/app.py
+++ b/solar_consumer/app.py
@@ -140,19 +140,25 @@ async def app(
                 else:
                     logger.info("Saving generation data to the Data Platform.")
                     if country == "gb" and "gsp_id" in data.columns:
-                        # Process each GSP location individually so that a failure or missing
+                        # Process each GSP location in parallel so that a failure or missing
                         # location data for one GSP does not block all others.
                         gsp_ids = data["gsp_id"].unique()
-                        logger.info(f"Saving GB generation data for {len(gsp_ids)} GSP locations one by one.")
-                        for gsp_id in gsp_ids:
-                            gsp_data = data[data["gsp_id"] == gsp_id].copy()
-                            try:
-                                await save_generation_to_data_platform(
-                                    data_df=gsp_data, client=client, config_name=country
+                        logger.info(f"Saving GB generation data for {len(gsp_ids)} GSP locations in parallel.")
+                        results = await asyncio.gather(
+                            *[
+                                save_generation_to_data_platform(
+                                    data_df=data[data["gsp_id"] == gsp_id].copy(),
+                                    client=client,
+                                    config_name=country,
                                 )
-                            except Exception as e:
+                                for gsp_id in gsp_ids
+                            ],
+                            return_exceptions=True,
+                        )
+                        for gsp_id, result in zip(gsp_ids, results):
+                            if isinstance(result, Exception):
                                 logger.error(
-                                    f"Failed to save generation data for gsp_id={gsp_id}: {e}"
+                                    f"Failed to save generation data for gsp_id={gsp_id}: {result}"
                                 )
                     else:
                         await save_generation_to_data_platform(data_df=data, client=client, config_name=country)

--- a/solar_consumer/app.py
+++ b/solar_consumer/app.py
@@ -139,29 +139,7 @@ async def app(
                     await save_forecasts_to_data_platform(data_df=data, client=client, model_tag=model_tag, model_version=__version__, init_time_utc=t0.to_pydatetime(), country=country)
                 else:
                     logger.info("Saving generation data to the Data Platform.")
-                    if country == "gb" and "gsp_id" in data.columns:
-                        # Process each GSP location in parallel so that a failure or missing
-                        # location data for one GSP does not block all others.
-                        gsp_ids = data["gsp_id"].unique()
-                        logger.info(f"Saving GB generation data for {len(gsp_ids)} GSP locations in parallel.")
-                        results = await asyncio.gather(
-                            *[
-                                save_generation_to_data_platform(
-                                    data_df=data[data["gsp_id"] == gsp_id].copy(),
-                                    client=client,
-                                    config_name=country,
-                                )
-                                for gsp_id in gsp_ids
-                            ],
-                            return_exceptions=True,
-                        )
-                        for gsp_id, result in zip(gsp_ids, results):
-                            if isinstance(result, Exception):
-                                logger.error(
-                                    f"Failed to save generation data for gsp_id={gsp_id}: {result}"
-                                )
-                    else:
-                        await save_generation_to_data_platform(data_df=data, client=client, config_name=country)
+                    await save_generation_to_data_platform(data_df=data, client=client, config_name=country)
 
                     # special save for Ned NL no curtailment
                     # we might want to make this more generic a bit later

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -241,22 +241,29 @@ async def _filter_existing_observations(
         await _execute_async_tasks(read_observations_tasks, ignore_exceptions=True)
 
     # Compare timestamps already in the data platform
-    existing_observations = []
+    # (existing_pairs built below, together with the filter)
+
+    # Build a set of (location_uuid, timestamp) pairs that already exist in the data platform.
+    # We must match on both dimensions so that a timestamp saved for one location does not
+    # accidentally suppress the same timestamp for a different location.
+    existing_pairs = set()
     for lid, task in zip(location_uuids, read_observations_tasks):
         try:
-            existing_observations.extend(task.result().values)
+            for obs in task.result().values:
+                existing_pairs.add((lid, obs.timestamp_utc))
         except Exception as e:
             logger.error(f"Failed to read observations for location_uuid {lid}: {e}")
 
-    existing_timestamps = {obs.timestamp_utc for obs in existing_observations}
-
-    # if any timestamps already in the data-platform, remove from data in app
-    idx = joined_df["target_datetime_utc"].isin(existing_timestamps)
+    # if any (location, timestamp) pairs already in the data-platform, remove from data in app
+    idx = joined_df.apply(
+        lambda row: (row["location_uuid"], row["target_datetime_utc"]) in existing_pairs,
+        axis=1,
+    )
     if idx.any():
-        location_uuids = joined_df.loc[idx, "location_uuid"].unique()
+        duplicate_location_uuids = joined_df.loc[idx, "location_uuid"].unique()
         logger.warning(
             f"Found {idx.sum()} values already existing in data platform "
-            f"for location_uuid {location_uuids}. "
+            f"for location_uuid {duplicate_location_uuids}. "
             "These values will be dropped."
         )
         joined_df = joined_df[~idx]

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -246,27 +246,35 @@ async def _filter_existing_observations(
     # Build a set of (location_uuid, timestamp) pairs that already exist in the data platform.
     # We must match on both dimensions so that a timestamp saved for one location does not
     # accidentally suppress the same timestamp for a different location.
-    existing_pairs = set()
+    existing_rows = []
     for lid, task in zip(location_uuids, read_observations_tasks):
         try:
             for obs in task.result().values:
-                existing_pairs.add((lid, obs.timestamp_utc))
+                existing_rows.append({"location_uuid": lid, "target_datetime_utc": obs.timestamp_utc})
         except Exception as e:
             logger.error(f"Failed to read observations for location_uuid {lid}: {e}")
 
     # if any (location, timestamp) pairs already in the data-platform, remove from data in app
-    idx = joined_df.apply(
-        lambda row: (row["location_uuid"], row["target_datetime_utc"]) in existing_pairs,
-        axis=1,
-    )
-    if idx.any():
-        duplicate_location_uuids = joined_df.loc[idx, "location_uuid"].unique()
-        logger.warning(
-            f"Found {idx.sum()} values already existing in data platform "
-            f"for location_uuid {duplicate_location_uuids}. "
-            "These values will be dropped."
+    if existing_rows:
+        existing_pairs_df = pd.DataFrame(existing_rows).assign(
+            target_datetime_utc=lambda df: pd.to_datetime(df["target_datetime_utc"])
         )
-        joined_df = joined_df[~idx]
+        existing_pairs_df["_exists"] = True
+
+        merged = joined_df.merge(
+            existing_pairs_df,
+            on=["location_uuid", "target_datetime_utc"],
+            how="left",
+        )
+        idx = merged["_exists"].fillna(False)
+        if idx.any():
+            duplicate_location_uuids = joined_df.loc[idx, "location_uuid"].unique()
+            logger.warning(
+                f"Found {idx.sum()} values already existing in data platform "
+                f"for location_uuid {duplicate_location_uuids}. "
+                "These values will be dropped."
+            )
+            joined_df = joined_df[~idx.values]
 
     return joined_df
 

--- a/tests/unit/test_save_forecast.py
+++ b/tests/unit/test_save_forecast.py
@@ -713,3 +713,147 @@ class TestFilterExistingObservations(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(client_mock.get_observations_as_timeseries.call_count, 3)
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_cross_location_timestamp_isolation(self, client_mock):
+        """
+        Core regression test for the per-location filtering fix.
+
+        If location A already has T=12:00 saved, that must NOT cause T=12:00
+        to be dropped for location B, which has never been saved.
+
+        Old (buggy) behaviour: flat timestamp set caused cross-location suppression.
+        New (fixed) behaviour: filter on (location_uuid, timestamp) pairs.
+        """
+        lid_a = str(uuid.uuid4())
+        lid_b = str(uuid.uuid4())
+        ts = pd.Timestamp("2024-01-01T12:00:00", tz="UTC")
+
+        # Both locations have the same timestamp in joined_df
+        joined_df = pd.DataFrame([
+            {"location_uuid": lid_a, "target_datetime_utc": ts},
+            {"location_uuid": lid_b, "target_datetime_utc": ts},
+        ])
+
+        # Only location A's timestamp exists in the data platform
+        existing_for_a = [
+            dp.GetObservationsAsTimeseriesResponseValue(
+                timestamp_utc=ts, value_fraction=0.5, effective_capacity_watts=1_000_000
+            )
+        ]
+
+        def mock_get_obs(req: dp.GetObservationsAsTimeseriesRequest):
+            if req.location_uuid == lid_a:
+                return dp.GetObservationsAsTimeseriesResponse(values=existing_for_a)
+            return dp.GetObservationsAsTimeseriesResponse(values=[])
+
+        client_mock.get_observations_as_timeseries = AsyncMock(side_effect=mock_get_obs)
+
+        result = await _filter_existing_observations(
+            joined_df=joined_df,
+            client=client_mock,
+            observer_name="pvlive_in_day",
+        )
+
+        # Only location A's row should be dropped; location B's row must survive
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result["location_uuid"].iloc[0], lid_b)
+        self.assertEqual(result["target_datetime_utc"].iloc[0], ts)
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_partial_drop_per_location_keeps_other_timestamps(self, client_mock):
+        """
+        For a single location with multiple timestamps, only the already-saved
+        timestamps are dropped — the others are kept.
+        """
+        lid = str(uuid.uuid4())
+        ts_saved = pd.Timestamp("2024-01-01T00:00:00", tz="UTC")
+        ts_new_1 = pd.Timestamp("2024-01-01T00:30:00", tz="UTC")
+        ts_new_2 = pd.Timestamp("2024-01-01T01:00:00", tz="UTC")
+
+        joined_df = self._make_joined_df([lid], [ts_saved, ts_new_1, ts_new_2])
+
+        existing = [
+            dp.GetObservationsAsTimeseriesResponseValue(
+                timestamp_utc=ts_saved, value_fraction=0.3, effective_capacity_watts=1_000_000
+            )
+        ]
+        client_mock.get_observations_as_timeseries = AsyncMock(
+            return_value=dp.GetObservationsAsTimeseriesResponse(values=existing)
+        )
+
+        result = await _filter_existing_observations(
+            joined_df=joined_df,
+            client=client_mock,
+            observer_name="pvlive_in_day",
+        )
+
+        self.assertEqual(len(result), 2)
+        remaining_timestamps = set(result["target_datetime_utc"])
+        self.assertIn(ts_new_1, remaining_timestamps)
+        self.assertIn(ts_new_2, remaining_timestamps)
+        self.assertNotIn(ts_saved, remaining_timestamps)
+
+    @patch("dp_sdk.ocf.dp.DataPlatformDataServiceStub")
+    async def test_multiple_locations_independent_filtering(self, client_mock):
+        """
+        Each location's observations are filtered independently.
+
+        - Location A: T1 already saved → T1 dropped, T2 kept
+        - Location B: nothing saved  → both T1 and T2 kept
+        - Location C: T1 and T2 both saved → both dropped
+        """
+        lid_a = str(uuid.uuid4())
+        lid_b = str(uuid.uuid4())
+        lid_c = str(uuid.uuid4())
+        t1 = pd.Timestamp("2024-01-01T00:00:00", tz="UTC")
+        t2 = pd.Timestamp("2024-01-01T00:30:00", tz="UTC")
+
+        joined_df = self._make_joined_df([lid_a, lid_b, lid_c], [t1, t2])
+        # 6 rows total: 2 per location
+
+        existing_a = [
+            dp.GetObservationsAsTimeseriesResponseValue(
+                timestamp_utc=t1, value_fraction=0.1, effective_capacity_watts=1_000_000
+            )
+        ]
+        existing_c = [
+            dp.GetObservationsAsTimeseriesResponseValue(
+                timestamp_utc=t1, value_fraction=0.2, effective_capacity_watts=1_000_000
+            ),
+            dp.GetObservationsAsTimeseriesResponseValue(
+                timestamp_utc=t2, value_fraction=0.3, effective_capacity_watts=1_000_000
+            ),
+        ]
+
+        def mock_get_obs(req: dp.GetObservationsAsTimeseriesRequest):
+            if req.location_uuid == lid_a:
+                return dp.GetObservationsAsTimeseriesResponse(values=existing_a)
+            elif req.location_uuid == lid_c:
+                return dp.GetObservationsAsTimeseriesResponse(values=existing_c)
+            return dp.GetObservationsAsTimeseriesResponse(values=[])
+
+        client_mock.get_observations_as_timeseries = AsyncMock(side_effect=mock_get_obs)
+
+        result = await _filter_existing_observations(
+            joined_df=joined_df,
+            client=client_mock,
+            observer_name="pvlive_in_day",
+        )
+
+        # Expected survivors: A→T2, B→T1, B→T2  (3 rows)
+        self.assertEqual(len(result), 3)
+
+        result_a = result[result["location_uuid"] == lid_a]
+        result_b = result[result["location_uuid"] == lid_b]
+        result_c = result[result["location_uuid"] == lid_c]
+
+        # A: only T2 survives
+        self.assertEqual(len(result_a), 1)
+        self.assertEqual(result_a["target_datetime_utc"].iloc[0], t2)
+
+        # B: both T1 and T2 survive
+        self.assertEqual(len(result_b), 2)
+
+        # C: nothing survives
+        self.assertEqual(len(result_c), 0)


### PR DESCRIPTION
# Pull Request

## Description

`_filter_existing_observations` in `save_data_platform.py` used a flat set of timestamps to determine
which observations had already been saved. This caused cross-location contamination: if **any** location
already had an observation at `T=12:00`, that timestamp would be dropped for **every other location** too
— even if those locations had never been saved.

This meant that once the national location (`gsp_id=0`) had values saved, all subsequent GSP locations
sharing the same timestamps would have their observations silently discarded on re-runs.

Issue: #217

**Changes:**

- `save_data_platform.py`: Fixed `_filter_existing_observations` to filter on `(location_uuid, timestamp)`
  pairs instead of timestamps alone, so that duplicate-dropping is scoped per location — a saved value at
  `T=12:00` for location A no longer suppresses the same timestamp for location B

## How Has This Been Tested?

Ran the pipeline locally against a local data platform instance with `UK_PVLIVE_N_GSPS=10`:

- All 9 matched GSP locations processed in a single call
- Deduplication correctly identified 36 already-existing `(location, timestamp)` pairs and dropped only
  those — other locations' data was not affected
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
