### PR TITLE
refactor: fetch GSP IDs directly from PVLive instead of using a hardc…

### DIFF
--- a/solar_consumer/data/fetch_gb_data.py
+++ b/solar_consumer/data/fetch_gb_data.py
@@ -92,8 +92,6 @@ def fetch_gb_data_historic(regime: str) -> pd.DataFrame:
     """
     gb_pvlive_domain_url = os.getenv("GB_PVLIVE_DOMAIN_URL", GB_PVLIVE_DOMAIN_URL)
     pvlive = PVLive(domain_url=gb_pvlive_domain_url)
-    # ignore these gsp ids from PVLive as they are no longer used
-    ignore_gsp_ids = [4, 5, 17, 41, 53, 56, 75, 122, 139, 140, 143, 157, 158, 163, 225, 257, 310]
 
     datetime_utc = datetime.now(timezone.utc)
 
@@ -110,13 +108,14 @@ def fetch_gb_data_historic(regime: str) -> pd.DataFrame:
         )   - timedelta(minutes=30)  # so we don't include 00:00
 
     all_gsps_yields = []
-    n_gsps = int(os.getenv("UK_PVLIVE_N_GSPS", 342))
-    for gsp_id in range(0, n_gsps + 1):
-        if gsp_id in ignore_gsp_ids:
-            continue
+    gsp_ids = pvlive.gsp_ids
+    n_gsps = os.getenv("UK_PVLIVE_N_GSPS")
+    if n_gsps is not None:
+        gsp_ids = gsp_ids[: int(n_gsps)]
+    for gsp_id in gsp_ids:
 
         logger.info(
-            f"Getting data for GSP ID {gsp_id}, out of {n_gsps} GSPs, for regime {regime}"
+            f"Getting data for GSP ID {gsp_id}, out of {len(gsp_ids)} GSPs, for regime {regime}"
         )
 
         gsp_yield_df: pd.DataFrame = pvlive.between(

--- a/tests/unit/test_fetch_data.py
+++ b/tests/unit/test_fetch_data.py
@@ -177,8 +177,8 @@ def test_gb_historic_inday():
 
     df = fetch_data(country = "gb", historic_or_forecast = "historic")
 
-    # In the range 0-10, IDs 4 and 5 are ignored, so 9 GSPs are active
-    n_active = 9
+    # pvlive.gsp_ids[:10] returns 10 GSPs
+    n_active = 10
     # Each GSP should have 3 to 5 data points for a 2-hour backfill
     assert n_active * 3 <= len(df) <= n_active * 5
 
@@ -191,8 +191,8 @@ def test_gb_historic_day_after():
 
     df = fetch_data(country = "gb", historic_or_forecast = "historic")
 
-    # In the range 0-10, IDs 4 and 5 are ignored, so 9 GSPs are active
-    n_active = 9
+    # pvlive.gsp_ids[:10] returns 10 GSPs
+    n_active = 10
     # Each GSP should have around 48 data points, but we use a lower bound 
     # because the API currently returns fewer slots (~37) for some GSPs.
     assert n_active * 30 <= len(df) <= n_active * 48


### PR DESCRIPTION
# Pull Request

## Description

Refactors `fetch_gb_data_historic` in `fetch_gb_data.py` to source GSP IDs directly from the PVLive client (`pvlive.gsp_ids`) instead of relying on a hardcoded `ignore_gsp_ids` list and a `range`-based loop.

Previously, the code maintained a manually curated list of 17 GSP IDs to skip (e.g. 4, 5, 17, 41, …) because they were considered inactive. This list was brittle — it required manual updates whenever PVLive's registry changed and could silently produce incorrect results if IDs were added or retired.

The new approach delegates GSP discovery entirely to the PVLive client, which already exposes the set of active GSP IDs via `pvlive.gsp_ids`. The optional `UK_PVLIVE_N_GSPS` environment variable still works, but now slices the client-provided list rather than capping a `range()`. Unit tests have been updated to reflect the correct active GSP count (10, not 9) now that the two formerly ignored IDs (4 and 5) within the first 10 are handled by PVLive itself.

Fixes #

## How Has This Been Tested?

The existing unit tests in `tests/unit/test_fetch_data.py` were updated and verified:

- `test_gb_historic_inday` — sets `UK_PVLIVE_N_GSPS=10`, calls `fetch_data(country="gb", historic_or_forecast="historic")` with regime `in-day`, and asserts the returned DataFrame has between `10 * 3` and `10 * 5` rows (one entry per 30-min slot across a 2-hour backfill window).
- `test_gb_historic_day_after` — same setup with regime `day-after`, asserts between `10 * 30` and `10 * 48` rows (full-day half-hourly slots).

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
