### PR TITLE
chore: update .yml file

### DIFF
--- a/solar_consumer/data/gsp_merge_weights.yaml
+++ b/solar_consumer/data/gsp_merge_weights.yaml
@@ -9,141 +9,29 @@
 # used. Rather than skipping them entirely, we reconstruct their generation data
 # using weighted combinations of the replacement GSP IDs.
 #
+# Keys are sourced from the gsp_id column in the legacy database CSV.
 # Resolved using pvl._get_gsp_list() on 2026-05-26.
 
-# -----------------------------------------------------------------------
-# SPLITS: old combined region → reconstructed from its new constituent parts
-# (weight = 1.0 for each part, since generation fully decomposes)
-# -----------------------------------------------------------------------
-
-# COWL_1|ECLA_1 → COWL_1 (324) & ECLA_H (325)  (20250102)
-4:
-  pvlive_merge_weights:
-    - gsp_id: 324  # COWL_1
-      weight: 1.0
-    - gsp_id: 325  # ECLA_H
-      weight: 1.0
-
-# HARK_1|HUTT_1|RRIG → HARK_1|RRIG (328) & HUTT_1 (329)  (20250102)
-5:
-  pvlive_merge_weights:
-    - gsp_id: 328  # HARK_1|RRIG
-      weight: 1.0
-    - gsp_id: 329  # HUTT_1
-      weight: 1.0
-
-# KEAR_1|KEAR_3 → KEAR_1 (331) & KEAR_3 (332)  (20250102)
-17:
-  pvlive_merge_weights:
-    - gsp_id: 331  # KEAR_1
-      weight: 1.0
-    - gsp_id: 332  # KEAR_3
-      weight: 1.0
-
-# PEHS_P|STRI_P → PEHS_P (333) & STRI_P (336)  (20250102)
-41:
-  pvlive_merge_weights:
-    - gsp_id: 333  # PEHS_P
-      weight: 1.0
-    - gsp_id: 336  # STRI_P
-      weight: 1.0
-
-# HACK_1 (old, pre-HACK_6 split) → HACK_1 (326) & HACK_6 (327)  (20250109)
-# Old region was split: HACK_6 was carved out. Reconstruct by summing both.
-53:
-  pvlive_merge_weights:
-    - gsp_id: 326  # HACK_1
-      weight: 1.0
-    - gsp_id: 327  # HACK_6
-      weight: 1.0
-
-# WHAM_1 (old, pre-ISLI_1 split) → WHAM_1 (338) & ISLI_1 (330)  (20250109)
-# Old region was split: ISLI_1 was carved out. Reconstruct by summing both.
-56:
-  pvlive_merge_weights:
-    - gsp_id: 338  # WHAM_1
-      weight: 1.0
-    - gsp_id: 330  # ISLI_1
-      weight: 1.0
-
-# ACTL_C|WISD_1|WISD_6 → ACTL_C (318) & WISD_1 (341) & WISD_6 (342)  (20250109)
-75:
-  pvlive_merge_weights:
-    - gsp_id: 318  # ACTL_C
-      weight: 1.0
-    - gsp_id: 341  # WISD_1
-      weight: 1.0
-    - gsp_id: 342  # WISD_6
-      weight: 1.0
-
-# WIMBN1|WIMBS1 → WIMBN1 (339) & WIMBS1 (340)  (20250109)
-122:
-  pvlive_merge_weights:
-    - gsp_id: 339  # WIMBN1
-      weight: 1.0
-    - gsp_id: 340  # WIMBS1
-      weight: 1.0
-
-# CANTN1|RICH_J|RICH1 → CANTN1 (323) & RICH_J|RICH1 (334)  (20250109)
-139:
-  pvlive_merge_weights:
-    - gsp_id: 323  # CANTN1
-      weight: 1.0
-    - gsp_id: 334  # RICH_J|RICH1
-      weight: 1.0
-
-# IVER_1|IVER_6 → IVER_1 (345) & IVER_6 (346)  (20251204)
-140:
-  pvlive_merge_weights:
-    - gsp_id: 345  # IVER_1
-      weight: 1.0
-    - gsp_id: 346  # IVER_6
-      weight: 1.0
-
 # BRLE_1|FLEE_1 → BRLE_1 (343) & FLEE_1 (344)  (20251204)
-143:
+41:
   pvlive_merge_weights:
     - gsp_id: 343  # BRLE_1
       weight: 1.0
     - gsp_id: 344  # FLEE_1
       weight: 1.0
 
+# IVER_1|IVER_6 → IVER_1 (345) & IVER_6 (346)  (20251204)
+158:
+  pvlive_merge_weights:
+    - gsp_id: 345  # IVER_1
+      weight: 1.0
+    - gsp_id: 346  # IVER_6
+      weight: 1.0
+
 # SEAB1|SAFO_1 → SEAB1 (348) & SAFO_1 (347)  (20251204)
-# gsp_id=257 confirmed from Data Platform: location registered as "seab1|safo_1"
-# (gsp_id=157 was incorrect — 157 never existed in PVLive, IDs jump 156→159)
 257:
   pvlive_merge_weights:
     - gsp_id: 348  # SEAB1
       weight: 1.0
     - gsp_id: 347  # SAFO_1
       weight: 1.0
-
-# -----------------------------------------------------------------------
-# SPECIAL CASES
-# -----------------------------------------------------------------------
-
-# ARMO_P (old, pre-HARG_P subtraction):
-# The current gsp_id=12 is 'ARMO_P|HARG_P' (combined). HARG_P has no standalone
-# current ID, so we use the full combined generation as a proxy for old ARMO_P (ID 158).
-158:
-  pvlive_merge_weights:
-    - gsp_id: 12   # ARMO_P|HARG_P (new combined region, weight=1.0 gives full generation)
-      weight: 1.0
-
-# -----------------------------------------------------------------------
-# BARKW3 NOTE (20250109): BARKC1 was split from BARKW3 and renamed to
-# BARKR_A (320) and BARKR_C (321). BARKW3 (322) is still active in PVLive
-# and is fetched directly — no remapping entry needed.
-# No confirmed old predecessor ID for BARKW3 was found; the previous
-# entry mapping gsp_id=257 to BARKR_A+BARKR_C was incorrect (257=SEAB1|SAFO_1).
-
-# -----------------------------------------------------------------------
-# DEPRECATED / REMOVED — no remapping possible
-# (these were not real regions; no source data exists)
-# -----------------------------------------------------------------------
-# ID 163 — likely BESW_1 (_E), not a real region, removed 20250102
-# ID 310 — likely RASS_1 (_E) or WILL_1 (_E), not a real region, removed 20250102
-#
-# These IDs are absent from pvlive.gsp_ids and have no entry in this config,
-# so they are automatically never processed. No action is required here.
-

--- a/tests/unit/test_fetch_data.py
+++ b/tests/unit/test_fetch_data.py
@@ -178,10 +178,9 @@ def test_gb_historic_inday():
     df = fetch_data(country = "gb", historic_or_forecast = "historic")
 
     # With UK_PVLIVE_MAX_GSP_ID=9 (filter: id <= 9), PVLive returns 8 live GSPs
-    # (IDs 4 and 5 are absent from the registry). However, IDs 4 and 5 are
-    # configured in gsp_merge_weights and are reconstructed from their split
-    # replacement GSPs — so the total is 10 GSPs processed.
-    n_gsps = 10
+    # (IDs 1,2,3,4,6,7,8,9 — gsp_id=0 national is not in pvlive.gsp_ids,
+    # gsp_id=5 is absent from PVLive and removed from gsp_merge_weights).
+    n_gsps = 8
     # Each GSP should have 3 to 7 data points for a 2-hour backfill window
     # (30-min slots over a ~2.5h window: t-120 to t+30)
     assert n_gsps * 3 <= len(df) <= n_gsps * 7
@@ -196,10 +195,9 @@ def test_gb_historic_day_after():
     df = fetch_data(country = "gb", historic_or_forecast = "historic")
 
     # With UK_PVLIVE_MAX_GSP_ID=9 (filter: id <= 9), PVLive returns 8 live GSPs
-    # (IDs 4 and 5 are absent from the registry). However, IDs 4 and 5 are
-    # configured in gsp_merge_weights and are reconstructed from their split
-    # replacement GSPs — so the total is 10 GSPs processed.
-    n_gsps = 10
+    # (IDs 1,2,3,4,6,7,8,9 — gsp_id=0 national is not in pvlive.gsp_ids,
+    # gsp_id=5 is absent from PVLive and removed from gsp_merge_weights).
+    n_gsps = 8
     # Each GSP should have around 48 data points, but we use a lower bound
     # because the API currently returns fewer slots (~37) for some GSPs.
     assert n_gsps * 30 <= len(df) <= n_gsps * 48


### PR DESCRIPTION
# Pull Request

## Description

Fixes incorrect GSP ID mappings in `gsp_merge_weights.yaml` by cross-referencing the legacy database CSV (`gsp_from_legacy_database.csv`). The previous mappings had incorrect YAML keys — they did not match the `gsp_id` column in the legacy database, meaning remapping targets were being resolved against the wrong regions.


[Issue](https://github.com/openclimatefix/solar-consumer/issues/227) 
### Changes made

**Removed entries (20250102 & 20250109 NESO changelog splits):**
These 10 old combined GSP IDs no longer exist in PVLive — confirmed by querying `pvlive.gsp_ids` directly. Since the constituent parts are now individually registered and fetched, no reconstruction is needed. The Data Platform has no locations registered for these old combined IDs either.

| gsp_id | Region | Changelog |
|--------|--------|-----------|
| 5 | ACTL_C\|WISD_1\|WISD_6 | 20250109 |
| 17 | BARKC1\|BARKW3 | 20250109 |
| 53 | CANTN1\|RICH_J\|RICH1 | 20250109 |
| 75 | COWL_1\|ECLA_H | 20250102 |
| 140 | HACK_1\|HACK_6 | 20250109 |
| 143 | HARK_1\|HUTT_1\|RRIG | 20250102 |
| 157 | ISLI_1\|WHAM_1 | 20250109 |
| 163 | KEAR_1\|KEAR_3 | 20250102 |
| 225 | PEHS_P\|STRI_P | 20250102 |
| 310 | WIMBN1\|WIMBS1 | 20250109 |

**Fixed keys (20251204 splits — kept, keys corrected from legacy DB CSV):**

| Old key | New key | Region | Source GSPs |
|---------|---------|--------|-------------|
| 143 | **41** | BRLE_1\|FLEE_1 | 343 (BRLE_1) + 344 (FLEE_1) |
| 140 | **158** | IVER_1\|IVER_6 | 345 (IVER_1) + 346 (IVER_6) |
| 257 | **257** ✅ | SEAB1\|SAFO_1 | 348 (SEAB1) + 347 (SAFO_1) |

**Resolved ARMO_P special case:**
The previous YAML incorrectly mapped `gsp_id=158 → pvlive 12`. Confirmed via `ListLocations` that the Data Platform has only one ARMO location (`gsp_id=12`, `armo_p|harg_p`) which is still active in PVLive and fetched directly. No YAML entry needed.

---



## How Has This Been Tested?

1. **Cross-referenced all YAML keys against legacy database CSV** — verified each key matches the `gsp_id` column for the correct `gsp_name`.

2. **Verified removed GSPs are absent from PVLive** — queried `pvlive.gsp_ids` directly; all 10 removed GSP IDs return `False` (not in the active registry).

3. **Verified all 349 GSPs from the legacy DB CSV against the Data Platform** — called `GetObservationsAsTimeseries` for every GSP ID across both `pvlive_in_day` and `pvlive_day_after` observers:
   - ✅ **336 GSPs** have observations
   - ❌ **2 GSPs** (DUBE_P `gsp_id=92`, IMPK_1 `gsp_id=151`) have 0 observations — confirmed via PVLive API that both report `capacity_mwp=0`, so they are intentionally filtered before saving
   - ❌ **11 GSPs** not in Data Platform — 10 are the intentionally excluded changelog splits; 1 is `G_EXTRA_12` (Off-NETS region with no DP location)

4. **End-to-end pipeline run** — ran `solar_consumer.app` with `SAVE_METHOD=data-platform` successfully; pipeline completed without errors with dev DP platform.

---

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

