### PR TITLE
Add retry logic for NL day-ahead price fetching

### DIFF
--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -306,7 +306,8 @@ def get_entsoe_day_prices(start: pd.Timestamp, end: pd.Timestamp, api_key: str) 
             logger.warning(f"Attempt {attempt + 1}/{max_retries} failed: {e}")
 
             if attempt == max_retries - 1:
-                raise
+                logger.exception("Failed to fetch ENTSOE day-ahead prices after all retries.")
+                raise e
 
             time.sleep(2**attempt)
 

--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -290,7 +290,25 @@ def get_entsoe_day_prices(start: pd.Timestamp, end: pd.Timestamp, api_key: str) 
     logger.debug(
         f"Fetching day-ahead prices from ENTSOE API for {country_code} from {start} to {end}"
     )
-    data = client.query_day_ahead_prices(country_code, start=start, end=end)
+    # Retry transient failures when fetching ENTSOE day-ahead prices.
+    max_retries = 3
+
+    for attempt in range(max_retries):
+        try:
+            data = client.query_day_ahead_prices(
+                country_code,
+                start=start,
+                end=end,
+            )
+            break
+
+        except Exception as e:
+            logger.warning(f"Attempt {attempt + 1}/{max_retries} failed: {e}")
+
+            if attempt == max_retries - 1:
+                raise
+
+            time.sleep(2**attempt)
 
     # validate data
     if data.empty:


### PR DESCRIPTION
# Pull Request
#232

## Description

Adds retry logic when fetching NL day-ahead electricity prices from the ENTSOE API to make the data retrieval more robust against temporary network or API failures.

### Changes
- Retry `query_day_ahead_prices` up to 3 times.
- Use exponential backoff (`1s`, `2s`, `4s`) between retries.
- Log failed retry attempts.
- Re-raise the exception after the final failed attempt.

Fixes #232

## How Has This Been Tested?

- Ran `ruff format solar_consumer/data/fetch_nl_data.py`
- Ran `ruff check solar_consumer/data/fetch_nl_data.py`
- Ran `pytest tests/unit/test_fetch_data_nl.py`

The full integration test suite requires Docker, which was not available in my local environment.

- [x] Yes

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (not required for this change)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
