### PR TITLE
Add support for fetching DE solar forecasts from ENTSO-E

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -13,6 +13,9 @@ CSV_DIR=None
 # ENTSO-E API key. Required for DE solar generation, and for NL day-ahead prices.
 APIKEY_ENTSOE=
 
+# Type of DE forecast to collect. Options are "day_ahead", "intraday", "current"
+DE_FORECAST_TYPE="day_ahead"
+
 # Optional Settings
 LOG_LEVEL=INFO
 BATCH_SIZE=1000

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This code can be used to download solar forecasts and save them to a PostgreSQL 
 We currently collect
 - UK: Forecast can be retreived from NESO. Generation Data can be retrevied from PVLive. 
 - NL: Generation values from Ned NL, both national and region. National Forecast values from Ned NL too. 
-- DE: Generation values from ENTSOE for several TSOs. 
+- DE: Generation values from ENTSOE for several TSOs. National forecast values from ENTSOE too. 
 - BE: Solar PV forecast data (national and regional) from Elia Open Data API.
 - India (Rajasthan): Real-time solar and wind generation data from RUVNL (Rajasthan Urja Vikas Nigam Limited).
 
@@ -35,6 +35,7 @@ Here are the different sources of data, and which methods can be used to save th
 | Ned-nl | 🇳🇱 | ✅ | ✅ | ✅ |
 | Ned-nl forecast | 🇳🇱 | ✅ | ✅ | ✅ |
 | Germany (ENTSOE) | 🇩🇪 |  ✅ | ✅ | ✅ |
+| Germany (ENTSOE) forecast | 🇩🇪 |  ✅ | ✅ | |
 | Elia Open Data | 🇧🇪 | ✅ | ✅ | |
 | RUVNL (Rajasthan SLDC) | 🇮🇳 | ✅ | ✅ | ✅ |
 
@@ -109,6 +110,7 @@ The package provides three main functionalities:
 - `UK_PVLIVE_BACKFILL_HOURS=2`: For UK PVLive, the amount of backfill hours we pull, when regime="in-day"
 - `UK_PVLIVE_DOMAIN_URL`: For UK PVLive, the domain URL to fetch data from. Defaults to "api.pvlive.uk"
 - `DE_BACKFILL_HOURS=24`: For DE (ENTSOE), the amount of backfill hours we pull. ENTSOE only publishes settled values, so we always pull a window of recent history and let the save step drop anything already stored.
+- `DE_FORECAST_TYPE=day_ahead`: For DE (ENTSOE) forecasts, which of the three ENTSOE forecasts to collect. Can be "day_ahead", "intraday" or "current". Each one is saved by its own forecaster, for example `entsoe-de-day-ahead`.
 - `NL_POTENTIAL_GENERATION`: boolen, to create and save a potential solar generation
 - `APIKEY_ENTSOE`: The ENTSOE api key. Needed for DE solar generation, and for NL day-ahead prices (used for NL potential generation). 
 

--- a/solar_consumer/app.py
+++ b/solar_consumer/app.py
@@ -17,6 +17,7 @@ from ocf import dp
 from pvsite_datamodel.connection import DatabaseConnection
 
 from solar_consumer import __version__  # Import version from __init__.py
+from solar_consumer.data.fetch_de_data import get_de_forecast_type
 from solar_consumer.fetch_data import fetch_data
 from solar_consumer.save.save_csv import save_forecasts_to_csv
 from solar_consumer.save.save_data_platform import (
@@ -57,7 +58,8 @@ async def app(
     elif country == "nl":
         model_tag = "ned-nl-national"
     elif country == "de":
-        model_tag = "entsoe-de"
+        # the three ENTSO-E forecasts each get their own forecaster
+        model_tag = f"entsoe-de-{get_de_forecast_type().replace('_', '-')}"
     elif country == "be":
         model_tag = "elia-be-forecast"
 

--- a/solar_consumer/constants.py
+++ b/solar_consumer/constants.py
@@ -22,6 +22,13 @@ DE_AREAS = {
     "transnetbw": "DE_TRANSNET",
 }
 
+# The ENTSO-E process types for the three published solar forecasts
+DE_FORECAST_PROCESS_TYPES = {
+    "day_ahead": "A01",
+    "intraday": "A40",
+    "current": "A18",
+}
+
 # TSO names, as used by the legacy site database sites
 DE_TSO_NAMES = {
     "50hertz": "50Hertz",

--- a/solar_consumer/data/fetch_de_data.py
+++ b/solar_consumer/data/fetch_de_data.py
@@ -1,7 +1,8 @@
-"""Get German solar generation from the ENTSO-E.
+"""Get German solar generation and forecasts from the ENTSO-E.
 
 Generation is published for each German TSO control area and Germany overall, 
 enabling both regional and national values to be saved to the data platform.
+Forecasts are national, and ENTSO-E publishes three of them: day ahead, intraday and current.
 """
 
 import os
@@ -12,7 +13,12 @@ from entsoe import EntsoePandasClient
 from entsoe.exceptions import NoMatchingDataError
 from loguru import logger
 
-from solar_consumer.constants import DE_AREAS, DE_SOLAR_PSR_TYPE, DE_TSO_NAMES
+from solar_consumer.constants import (
+    DE_AREAS,
+    DE_FORECAST_PROCESS_TYPES,
+    DE_SOLAR_PSR_TYPE,
+    DE_TSO_NAMES,
+)
 
 # Load environment variables
 dotenv.load_dotenv()
@@ -28,12 +34,29 @@ def get_entsoe_client() -> EntsoePandasClient:
     return EntsoePandasClient(api_key=api_key)
 
 
+def get_de_forecast_type() -> str:
+    """Get the type of forecast to collect: day_ahead, intraday or current."""
+    forecast_type = os.getenv("DE_FORECAST_TYPE", "day_ahead").lower()
+    if forecast_type not in DE_FORECAST_PROCESS_TYPES:
+        raise ValueError(
+            f"Unknown DE forecast type '{forecast_type}', "
+            f"expected one of {list(DE_FORECAST_PROCESS_TYPES)}"
+        )
+    return forecast_type
+
+
 def fetch_de_data(historic_or_forecast: str = "generation") -> pd.DataFrame:
+    """Fetch German solar forecast from the ENTSO-E API."""
+    if historic_or_forecast == "forecast":
+        return fetch_de_data_forecast()
+
+    return fetch_de_data_generation()
+
+
+def fetch_de_data_generation() -> pd.DataFrame:
     """
     Fetch solar generation from the German control areas (TSOs) and the national
     total via the ENTSO-E API.
-
-    Only 'generation' mode is supported for now
     
     Returns DataFrame with 5 columns:
       - target_datetime_utc (UTC date and time)
@@ -42,8 +65,6 @@ def fetch_de_data(historic_or_forecast: str = "generation") -> pd.DataFrame:
       - region (data platform join key, e.g. "de" or "50hertz")
       - tso_zone (TSO name, e.g. "50Hertz", or None for the national values)
     """
-    
-    assert historic_or_forecast == "generation", "Only 'generation' supported for the time being"
 
     # ENTSO-E only publishes settled values, so we always pull a window of recent history and
     # let the save step drop anything we already have.
@@ -95,6 +116,59 @@ def fetch_de_data(historic_or_forecast: str = "generation") -> pd.DataFrame:
     return df
 
 
+def fetch_de_data_forecast() -> pd.DataFrame:
+    """
+    Fetch the German national solar forecast via the ENTSO-E API.
+
+    Which of the three ENTSO-E forecasts is collected is set by DE_FORECAST_TYPE.
+
+    Returns DataFrame with 4 columns:
+      - target_datetime_utc (UTC date and time)
+      - solar_generation_kw (forecast generation in kilowatts)
+      - region (data platform join key, "de")
+      - forecast_type ("day_ahead", "intraday" or "current")
+    """
+    forecast_type = get_de_forecast_type()
+
+    # ENTSO-E publishes the forecast for the day ahead, so we pull today and tomorrow
+    start = pd.Timestamp.now(tz="UTC").floor("D")
+    end = start + pd.Timedelta(days=2)
+
+    logger.info(f"Fetching German {forecast_type} solar forecast from {start} to {end}")
+
+    region = "de"
+    forecast = _fetch_area_forecast(
+        client=get_entsoe_client(),
+        area=DE_AREAS[region],
+        start=start,
+        end=end,
+        process_type=DE_FORECAST_PROCESS_TYPES[forecast_type],
+    )
+
+    if forecast.empty:
+        logger.warning(f"No German {forecast_type} solar forecast data found")
+        return pd.DataFrame(
+            columns=[
+                "target_datetime_utc",
+                "solar_generation_kw",
+                "region",
+                "forecast_type",
+            ]
+        )
+
+    forecast["region"] = region
+    forecast["forecast_type"] = forecast_type
+    forecast = forecast.sort_values("target_datetime_utc").reset_index(drop=True)
+
+    logger.info(f"Assembled {len(forecast)} rows of German {forecast_type} solar forecast")
+    logger.debug(
+        f"Timestamps go from {forecast['target_datetime_utc'].min()} "
+        f"to {forecast['target_datetime_utc'].max()}"
+    )
+
+    return forecast
+
+
 def _fetch_area_generation(
     client: EntsoePandasClient, area: str, start: pd.Timestamp, end: pd.Timestamp
 ) -> pd.DataFrame:
@@ -103,20 +177,58 @@ def _fetch_area_generation(
     Returns a DataFrame with 'target_datetime_utc' and 'solar_generation_kw', which is empty
     if ENTSO-E has no data for this area and time window.
     """
-    empty = pd.DataFrame(columns=["target_datetime_utc", "solar_generation_kw"])
-
     try:
         data = client.query_generation(area, start=start, end=end, psr_type=DE_SOLAR_PSR_TYPE)
     except NoMatchingDataError:
         logger.warning(f"No matching ENTSO-E data for {area} between {start} and {end}")
-        return empty
+        data = None
+
+    return _process_de_data(data, area=area, data_type="generation")
+
+
+def _fetch_area_forecast(
+    client: EntsoePandasClient,
+    area: str,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    process_type: str,
+) -> pd.DataFrame:
+    """Fetch the solar forecast for one ENTSO-E area.
+
+    Returns a DataFrame with 'target_datetime_utc' and 'solar_generation_kw', which is empty
+    if ENTSO-E has no forecast for this area and time window.
+    """
+    try:
+        data = client.query_wind_and_solar_forecast(
+            area, start=start, end=end, psr_type=DE_SOLAR_PSR_TYPE, process_type=process_type
+        )
+    except NoMatchingDataError:
+        logger.warning(f"No matching ENTSO-E forecast for {area} between {start} and {end}")
+        data = None
+
+    return _process_de_data(data, area=area, data_type="forecast")
+
+
+def _process_de_data(data: pd.DataFrame | None, area: str, data_type: str) -> pd.DataFrame:
+    """
+    Common processing logic for both forecast and generation data.
+
+    Parameters:
+        data: Raw entsoe-py DataFrame, in the timezone of the area and in MW
+        area: The ENTSO-E area the data is for
+        data_type: Description for logging ("forecast" or "generation")
+    """
+    empty = pd.DataFrame(columns=["target_datetime_utc", "solar_generation_kw"])
 
     if data is None or data.empty:
         return empty
 
     solar = _get_solar_series(data)
     if solar is None:
-        logger.warning(f"No solar column found in ENTSO-E data for {area}, got {list(data.columns)}")
+        logger.warning(
+            f"No solar column found in ENTSO-E {data_type} data for {area}, "
+            f"got {list(data.columns)}"
+        )
         return empty
 
     solar = solar.dropna()

--- a/tests/unit/test_fetch_de_data.py
+++ b/tests/unit/test_fetch_de_data.py
@@ -48,6 +48,7 @@ def make_client(gen_df: pd.DataFrame, cap_df: pd.DataFrame | None = None) -> Mag
 @pytest.fixture(autouse=True)
 def _set_api_key(monkeypatch):
     monkeypatch.setenv("APIKEY_ENTSOE", "test-key")
+    monkeypatch.delenv("DE_FORECAST_TYPE", raising=False)
 
 
 @patch("solar_consumer.data.fetch_de_data.EntsoePandasClient")
@@ -198,6 +199,71 @@ def test_fetch_de_data_no_api_key(monkeypatch):
         fetch_de_data()
 
 
-def test_fetch_de_data_assert_on_invalid_mode():
-    with pytest.raises(AssertionError):
+@patch("solar_consumer.data.fetch_de_data.EntsoePandasClient")
+def test_fetch_de_data_forecast(mock_client_class):
+    """Fetch the German national day ahead solar forecast from ENTSO-E."""
+    client = MagicMock()
+    client.query_wind_and_solar_forecast.return_value = make_generation_df([1.0, 2.0])
+    mock_client_class.return_value = client
+
+    df = fetch_de_data(historic_or_forecast="forecast")
+
+    assert set(df.columns) == {
+        "target_datetime_utc",
+        "solar_generation_kw",
+        "region",
+        "forecast_type",
+    }
+    assert len(df) == 2
+    assert set(df["region"]) == {"de"}
+    assert set(df["forecast_type"]) == {"day_ahead"}
+    assert sorted(df["solar_generation_kw"]) == [1_000.0, 2_000.0]
+    assert str(df["target_datetime_utc"].min()) == "2025-07-11 00:00:00+00:00"
+
+    # the national area, solar only, and the day ahead forecast by default
+    assert client.query_wind_and_solar_forecast.call_args.args[0] == DE_AREAS["de"]
+    assert client.query_wind_and_solar_forecast.call_args.kwargs["psr_type"] == "B16"
+    assert client.query_wind_and_solar_forecast.call_args.kwargs["process_type"] == "A01"
+
+
+@pytest.mark.parametrize(
+    ("forecast_type", "process_type"),
+    [("day_ahead", "A01"), ("intraday", "A40"), ("current", "A18")],
+)
+@patch("solar_consumer.data.fetch_de_data.EntsoePandasClient")
+def test_fetch_de_data_forecast_types(mock_client_class, monkeypatch, forecast_type, process_type):
+    """DE_FORECAST_TYPE picks which of the three ENTSO-E forecasts we fetch."""
+    monkeypatch.setenv("DE_FORECAST_TYPE", forecast_type)
+    client = MagicMock()
+    client.query_wind_and_solar_forecast.return_value = make_generation_df([1.0])
+    mock_client_class.return_value = client
+
+    df = fetch_de_data(historic_or_forecast="forecast")
+
+    assert set(df["forecast_type"]) == {forecast_type}
+    assert client.query_wind_and_solar_forecast.call_args.kwargs["process_type"] == process_type
+
+
+def test_fetch_de_data_forecast_unknown_type(monkeypatch):
+    monkeypatch.setenv("DE_FORECAST_TYPE", "next_week")
+
+    with pytest.raises(ValueError, match="Unknown DE forecast type"):
         fetch_de_data(historic_or_forecast="forecast")
+
+
+@patch("solar_consumer.data.fetch_de_data.EntsoePandasClient")
+def test_fetch_de_data_forecast_no_data(mock_client_class):
+    """ENTSO-E having no forecast gives an empty DataFrame, rather than raising an error."""
+    client = MagicMock()
+    client.query_wind_and_solar_forecast.side_effect = NoMatchingDataError()
+    mock_client_class.return_value = client
+
+    df = fetch_de_data(historic_or_forecast="forecast")
+
+    assert df.empty
+    assert list(df.columns) == [
+        "target_datetime_utc",
+        "solar_generation_kw",
+        "region",
+        "forecast_type",
+    ]


### PR DESCRIPTION
# Pull Request

## Description

- added support for fetching Germany solar forecasts from ENTSOE
- it considers three different forecasts - current, intra-day and day-ahead

Fixes #https://github.com/openclimatefix/client-private/issues/491

## How Has This Been Tested?

- [x] tested with local data-platform and ENTSOE's API

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
