### PR TITLE
fix: don't fail NL generation when ENTSO-E API is down

### DIFF
--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -326,8 +326,17 @@ def get_entsoe_day_prices(start: pd.Timestamp, end: pd.Timestamp, api_key: str) 
             logger.warning(f"Attempt {attempt + 1}/{max_retries} failed: {e}")
 
             if attempt == max_retries - 1:
-                logger.exception("Failed to fetch ENTSOE day-ahead prices after all retries.")
-                raise
+                # ENTSOE being down should not stop us saving generation data.
+                # Carry on with no prices, so no curtailment adjustment is made.
+                logger.exception(
+                    "Failed to fetch ENTSOE day-ahead prices after all retries. "
+                    "Carrying on without prices, no curtailment adjustment will be made."
+                )
+                data = pd.DataFrame(
+                    columns=["NL_day_ahead_prices_euros_per_mwh", "target_datetime_utc"]
+                )
+                data.index.name = "target_datetime_utc"
+                break
 
             time.sleep(2**attempt)
 

--- a/solar_consumer/data/fetch_nl_data.py
+++ b/solar_consumer/data/fetch_nl_data.py
@@ -322,7 +322,7 @@ def get_entsoe_day_prices(start: pd.Timestamp, end: pd.Timestamp, api_key: str) 
                                              "target_datetime_utc"])
                 data.index.name = "target_datetime_utc"
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - prices are optional, generation must still save
             logger.warning(f"Attempt {attempt + 1}/{max_retries} failed: {e}")
 
             if attempt == max_retries - 1:


### PR DESCRIPTION
# Pull Request

## Description

- don't fail NL generation when ENTSO-E API is down

Fixes #

## How Has This Been Tested?

- [x] tested with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
