### PR TITLE
feat: add rolling capacity feature for DE

### DIFF
--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -834,6 +834,7 @@ def get_update_capacity_df(df: pd.DataFrame, rolling_capacity: bool = False) -> 
         identity_cols.append("energy_source")
     if rolling_capacity:
         # rolling uses the first value above the old capacity instead, so earlier values still fit
+        # effective_capacity_watts is the current capacity in the data platform
         df = df[df["solar_generation_kw"] * 1000 > df["effective_capacity_watts"]]
         df = df.sort_values(by="target_datetime_utc").groupby(identity_cols).head(1)
     else:

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -47,7 +47,8 @@ def _get_country_config(country: str) -> dict:
             "location_type": [dp.LocationType.NATION, dp.LocationType.STATE],
             "metadata_type": "string",
             "observer_name": "entsoe_de",
-            "country": "de"
+            "country": "de",
+            "rolling_capacity": True
         },
         "gb": {
             "required_observers": {"pvlive_in_day", "pvlive_day_after"},
@@ -377,6 +378,11 @@ async def save_generation_to_data_platform(
     id_key = config["id_key"]
     # capacity_col and capacity_multiplier are no longer needed as we standardized on capacity_kw
     metadata_type = config["metadata_type"]
+    rolling_capacity = config.get("rolling_capacity", False)
+
+    # dropping the source capacity makes the max generation fallback below kick in
+    if rolling_capacity:
+        data_df = data_df.drop(columns="capacity_kw", errors="ignore")
     
     # Determine required observers
     # If observer_name is in config (NL/BE), use it as the single required observer
@@ -525,7 +531,7 @@ async def save_generation_to_data_platform(
     # 2. Generate the UpdateLocationCapacityRequest objects from the DataFrame.
     # * Should only occur when the incoming data has a different capacity to that returned by the
     # * data platform. The most recent value for a given location is the one that is used.
-    updates_df = get_update_capacity_df(joined_df)
+    updates_df = get_update_capacity_df(joined_df, rolling_capacity=rolling_capacity)
 
     # Grouped by location so each location's updates are applied in series, see
     # _update_location_capacities. Different locations still update in parallel.
@@ -808,8 +814,11 @@ def format_metadata_from_dict(metadata):
     return metadata
 
 
-def get_update_capacity_df(df: pd.DataFrame) -> pd.DataFrame:
-    """Get the rows that need to be updated based on capacity change."""
+def get_update_capacity_df(df: pd.DataFrame, rolling_capacity: bool = False) -> pd.DataFrame:
+    """Get the rows that need to be updated based on capacity change.
+
+    With ``rolling_capacity`` the capacity only ever goes up, never down.
+    """
 
     # lets only consider non nans values
     df = df[~df["new_effective_capacity_watts"].isna()]
@@ -823,7 +832,12 @@ def get_update_capacity_df(df: pd.DataFrame) -> pd.DataFrame:
     identity_cols = ["location_uuid"]
     if "energy_source" in df.columns:
         identity_cols.append("energy_source")
-    df = df.sort_values(by="target_datetime_utc", ascending=False).groupby(identity_cols).head(1)
+    if rolling_capacity:
+        # rolling uses the first value above the old capacity instead, so earlier values still fit
+        df = df[df["solar_generation_kw"] * 1000 > df["effective_capacity_watts"]]
+        df = df.sort_values(by="target_datetime_utc").groupby(identity_cols).head(1)
+    else:
+        df = df.sort_values(by="target_datetime_utc", ascending=False).groupby(identity_cols).head(1)
 
     current_cap = df["effective_capacity_watts"]
     new_cap = df["new_effective_capacity_watts"]

--- a/tests/unit/test_save_de_generation_unit.py
+++ b/tests/unit/test_save_de_generation_unit.py
@@ -1,0 +1,81 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+from solar_consumer.save.save_data_platform import save_generation_to_data_platform
+
+# the capacity already stored in the data platform, 58212 MW
+STORED_CAPACITY_WATTS = 58_212_000_000
+# the installed capacity ENTSO-E reports, which is far too high, so we ignore it
+ENTSOE_CAPACITY_KW = 103_260_000
+
+TIMESTAMPS = [pd.to_datetime("2025-01-01T10:00:00Z"), pd.to_datetime("2025-01-01T11:00:00Z")]
+
+
+def make_mock_client() -> AsyncMock:
+    """A data platform client with one German location at STORED_CAPACITY_WATTS."""
+    mock_client = AsyncMock()
+
+    mock_observer = MagicMock()
+    mock_observer.observer_name = "entsoe_de"
+    mock_client.list_observers.return_value = MagicMock(observers=[mock_observer])
+
+    mock_location_response = MagicMock()
+    mock_location_response.to_dict.return_value = {
+        "locations": [
+            {
+                "location_uuid": "de-uuid",
+                "location_name": "de_germany",
+                "energy_source": "SOLAR",
+                "metadata": {
+                    "region": {"string_value": "de"},
+                    "country": {"string_value": "de"},
+                },
+                "effective_capacity_watts": STORED_CAPACITY_WATTS,
+            }
+        ]
+    }
+    mock_client.list_locations.return_value = mock_location_response
+
+    return mock_client
+
+
+def make_de_data(max_generation_kw: float) -> pd.DataFrame:
+    """German generation as ENTSO-E gives it to us, peaking at max_generation_kw first."""
+    return pd.DataFrame(
+        {
+            "target_datetime_utc": TIMESTAMPS,
+            "solar_generation_kw": [max_generation_kw, max_generation_kw / 2],
+            "region": ["de", "de"],
+            "capacity_kw": [float(ENTSOE_CAPACITY_KW)] * 2,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_de_generation_capacity_not_lowered():
+    """Generation below the stored capacity leaves it alone, and the ENTSO-E capacity is ignored."""
+    mock_client = make_mock_client()
+
+    await save_generation_to_data_platform(
+        make_de_data(max_generation_kw=40_000_000), mock_client, config_name="de"
+    )
+
+    mock_client.update_location.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_de_generation_capacity_raised_to_max_generation():
+    """Generation above the stored capacity rolls the capacity up to that new maximum."""
+    mock_client = make_mock_client()
+
+    await save_generation_to_data_platform(
+        make_de_data(max_generation_kw=60_000_000), mock_client, config_name="de"
+    )
+
+    mock_client.update_location.assert_called_once()
+    request = mock_client.update_location.call_args.args[0]
+    assert request.new_effective_capacity_watts == 60_000_000_000
+    # dated from the peak, not the end of the batch, so the peak fits under the new capacity
+    assert request.valid_from_utc == TIMESTAMPS[0]


### PR DESCRIPTION
# Pull Request

## Description

- added `rolling_capacity` bool in the config for DE
- ignores the capacity from entsoe
- Uses the max_generation of today as the capacity if it is greater than the stored capacity in data-platform

Fixes #https://github.com/openclimatefix/client-private/issues/614

## How Has This Been Tested?

- [x] added test

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
