### PR TITLE
update locations one by one

### DIFF
--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -576,7 +576,8 @@ async def save_generation_to_data_platform(
         update_count = sum(len(reqs) for reqs in requests_by_location.values())
         logger.info(f"updating {update_count} {country.upper()} location capacities")
         # Lets up date the locations one by one, otherwise the data-platform has too much load
-        # A build update would help this
+        # and cause some other issues
+        # A bulk-update would speed this up
         # https://github.com/openclimatefix/data-platform/issues/199
         for reqs in requests_by_location.values():
             await _execute_async_tasks(

--- a/solar_consumer/save/save_data_platform.py
+++ b/solar_consumer/save/save_data_platform.py
@@ -575,14 +575,16 @@ async def save_generation_to_data_platform(
     if requests_by_location:
         update_count = sum(len(reqs) for reqs in requests_by_location.values())
         logger.info(f"updating {update_count} {country.upper()} location capacities")
-        # NL was previously ignoring these exceptions
-        await _execute_async_tasks(
-            [
-                asyncio.create_task(_update_location_capacities(client, reqs))
-                for reqs in requests_by_location.values()
-            ],
-            ignore_exceptions=True,
-        )
+        # Lets up date the locations one by one, otherwise the data-platform has too much load
+        # A build update would help this
+        # https://github.com/openclimatefix/data-platform/issues/199
+        for reqs in requests_by_location.values():
+            await _execute_async_tasks(
+                [
+                    asyncio.create_task(_update_location_capacities(client, reqs))
+                ],
+                ignore_exceptions=True,
+            )
 
     # Determine observer name based on country
     observer_name = config["observer_name"]


### PR DESCRIPTION
# Pull Request

## Description

Lets save updates to location one by one. If we do them all at once, it seems to over laod the data-paltform a bit.

Note: this will slow down the solar-consumer, but for the UK, the data is less critical. This seems to only happen once a day for the UK

This helps with, but does not solve - https://github.com/openclimatefix/data-platform/issues/199

## How Has This Been Tested?

- [x] CI tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
